### PR TITLE
Return empty string; Fix null crash; Add tests; camelCase

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,20 @@
-function classnames() {
+function classNames() {
 	var args = arguments, classes = [];
 	for (var i = 0; i < args.length; i++) {
-		if (args[i] && 'string' === typeof args[i]) {
-			classes.push(args[i]);
-		} else if ('object' === typeof args[i]) {
-			classes = classes.concat(Object.keys(args[i]).filter(function(cls) {
-				return args[i][cls];
+		var arg = args[i];
+		if (arg == null) {
+			continue;
+		}
+
+		if ('string' === typeof arg) {
+			classes.push(arg);
+		} else if ('object' === typeof arg) {
+			classes = classes.concat(Object.keys(arg).filter(function(cls) {
+				return arg[cls];
 			}));
 		}
 	}
-	return classes.join(' ') || undefined;
+	return classes.join(' ') || '';
 }
 
-module.exports = classnames;
+module.exports = classNames;

--- a/tests.js
+++ b/tests.js
@@ -1,9 +1,9 @@
 var assert = require("assert");
-var classnames = require('./');
+var classNames = require('./');
 
-describe('classnames', function() {
+describe('classNames', function() {
   it('keeps object keys with truthy values', function() {
-    assert.equal(classnames({
+    assert.equal(classNames({
       a: true,
       b: false,
       c: 0,
@@ -14,10 +14,14 @@ describe('classnames', function() {
   });
 
   it('joins arrays of class names and ignore falsy values', function() {
-    assert.equal(classnames('a', 0, 'b'), 'a b');
+    assert.equal(classNames('a', 0, null, undefined, 'b'), 'a b');
   });
 
   it('supports heterogenous arguments', function() {
-    assert.equal(classnames({a: true}, 'b', 0), 'a b');
+    assert.equal(classNames({a: true}, 'b', 0), 'a b');
+  });
+
+  it('returns an empty string for an empty configuration', function() {
+    assert.equal(classNames({}), '');
   });
 });


### PR DESCRIPTION
Fixes #3 (didn't feel like submitting individual PRs)

- Return empty string rather than `undefined`. Better behaviour imo and good for type checking in the future.
- camelCase `classNames`. This doesn't affect anything since the user can rename it anyways during `require`. Just thought it'd be more consistent.
- Make the function not crash on `null`.