### PR TITLE
Make code uglier and faster; more precise test

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 function classNames() {
-	var args = arguments, classes = [];
+	var args = arguments;
+	var classes = [];
+
 	for (var i = 0; i < args.length; i++) {
 		var arg = args[i];
 		if (arg == null) {
@@ -9,9 +11,12 @@ function classNames() {
 		if ('string' === typeof arg) {
 			classes.push(arg);
 		} else if ('object' === typeof arg) {
-			classes = classes.concat(Object.keys(arg).filter(function(cls) {
-				return arg[cls];
-			}));
+			for (var key in arg) {
+				if (!arg.hasOwnProperty(key) || !arg[key]) {
+					continue;
+				}
+				classes.push(key);
+			}
 		}
 	}
 	return classes.join(' ');

--- a/tests.js
+++ b/tests.js
@@ -13,8 +13,8 @@ describe('classNames', function() {
     }), 'a f');
   });
 
-  it('joins arrays of class names and ignore falsy values', function() {
-    assert.equal(classNames('a', 0, null, undefined, 'b'), 'a b');
+  it('joins arrays of class names and ignore non-string values', function() {
+    assert.equal(classNames('a', 0, null, undefined, true, 1, 'b'), 'a b');
   });
 
   it('supports heterogenous arguments', function() {


### PR DESCRIPTION
The function ignores non-string values. This has always been the case. No behavior change here.

Addtionally, the function's now consistently 4x faster due to less allocations. I kept the allocation for `classNames`, because it turns out that it's faster to mutate an array and join it at the end than to continuously append to a string, especially for slightly longer class names.

Fixes #5 