### PR TITLE
Fix behavior for non-zero params & empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,22 @@ Install with npm, or download the [UMD version](http://wzrd.in/standalone/classn
 npm install classnames
 ```
 
-The `classnames` function takes any number of arguments which can be a string or object.
-The argument `'foo'` is short for `{foo: true}`.  If the value of the key is falsy, it won't be included in the output.
+The `classNames` function takes any number of arguments which can be a string or object.
+The argument `'foo'` is short for `{foo: true}`. If the value of the key is falsy, it won't be included in the output.
 
 ```js
-classnames('foo', 'bar'); // => 'foo bar'
-classnames('foo', {bar: true}); // => 'foo bar'
-classnames({foo: true}, {bar: true}); // => 'foo bar'
-classnames({foo: true, bar: true}); // => 'foo bar'
+classNames('foo', 'bar'); // => 'foo bar'
+classNames('foo', {bar: true}); // => 'foo bar'
+classNames({foo: true}, {bar: true}); // => 'foo bar'
+classNames({foo: true, bar: true}); // => 'foo bar'
 
 // lots of arguments of various types
-classnames('foo', {bar: true, duck: false}, 'baz', {quux: true}) // => 'foo bar baz quux'
+classNames('foo', {bar: true, duck: false}, 'baz', {quux: true}) // => 'foo bar baz quux'
 
 // other falsy values are just ignored
-classnames(null, false, 'bar', undefined, 0, {baz: null}, ''); // => 'bar'
+classNames(null, false, 'bar', undefined, 0, 1, {baz: null}, ''); // => 'bar 1'
 
 // if you have an array of these, use apply
 var array = ['foo', {bar: true}];
-classnames.apply(null, array); // => 'foo bar'
+classNames.apply(null, array); // => 'foo bar'
 ```

--- a/index.js
+++ b/index.js
@@ -4,11 +4,11 @@ function classNames() {
 
 	for (var i = 0; i < args.length; i++) {
 		var arg = args[i];
-		if (arg == null) {
+		if (!arg) {
 			continue;
 		}
 
-		if ('string' === typeof arg) {
+		if ('string' === typeof arg || 'number' === typeof arg) {
 			classes.push(arg);
 		} else if ('object' === typeof arg) {
 			for (var key in arg) {

--- a/tests.js
+++ b/tests.js
@@ -13,12 +13,16 @@ describe('classNames', function() {
     }), 'a f');
   });
 
-  it('joins arrays of class names and ignore non-string values', function() {
-    assert.equal(classNames('a', 0, null, undefined, true, 1, 'b'), 'a b');
+  it('joins arrays of class names and ignore falsy values', function() {
+    assert.equal(classNames('a', 0, null, undefined, true, 1, 'b'), 'a 1 b');
   });
 
   it('supports heterogenous arguments', function() {
     assert.equal(classNames({a: true}, 'b', 0), 'a b');
+  });
+
+  it('should be trimmed', function() {
+    assert.equal(classNames('', 'b', {}, ''), 'b');
   });
 
   it('returns an empty string for an empty configuration', function() {


### PR DESCRIPTION
A bit trivial but this was in discordance with the README, which stated
that "falsy keys won't be included". Previously `1` was ignored.

Same for empty string. `c('a', '')` gave `"a "`. Fixed that.

P.S. I hate JS implicit conversion and falsy values