### PR TITLE
Simplify loop to only the asserted case

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,9 @@ function classNames() {
 			classes.push(arg);
 		} else if ('object' === typeof arg) {
 			for (var key in arg) {
-				if (!arg.hasOwnProperty(key) || !arg[key]) {
-					continue;
+				if (arg.hasOwnProperty(key) && arg[key]) {
+					classes.push(key);
 				}
-				classes.push(key);
 			}
 		}
 	}


### PR DESCRIPTION
This prevents needing to use `continue` and explicitly defines the case
where the class should be added.