### PR TITLE
package: remove unnecessary pathing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/JedWatson/classnames.git"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha tests.js"
+    "test": "mocha tests.js"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
npm automatically includes `~/node_modules/.bin` in the PATH when running scripts; so there is no need to specify this.

It will not revert to the globally installed `mocha` unless the package is missing.