### PR TITLE
Accept array arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install with npm, or download the [UMD version](http://wzrd.in/standalone/classn
 npm install classnames
 ```
 
-The `classNames` function takes any number of arguments which can be a string or object.
+The `classNames` function takes any number of arguments which can be strings, objects, or arrays that contain strings, objects, and other arrays.
 The argument `'foo'` is short for `{foo: true}`. If the value of the key is falsy, it won't be included in the output.
 
 ```js
@@ -24,9 +24,11 @@ classNames('foo', {bar: true, duck: false}, 'baz', {quux: true}) // => 'foo bar 
 // other falsy values are just ignored
 classNames(null, false, 'bar', undefined, 0, 1, {baz: null}, ''); // => 'bar 1'
 
-// if you have an array of these, use apply
-var array = ['foo', {bar: true}];
-classNames.apply(null, array); // => 'foo bar'
+// using arrays
+classNames(['foo', 'bar']); // => 'foo bar'
+classNames(['foo', 'bar'], 'baz'); // => 'foo bar baz'
+classNames(['foo', ['bar', 'baz']]); // => 'foo bar baz'
+classNames(['foo', [{bar: true, baz: false}]]); // => 'foo bar'
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -3,22 +3,35 @@ function classNames() {
 	var classes = [];
 
 	for (var i = 0; i < args.length; i++) {
-		var arg = args[i];
-		if (!arg) {
-			continue;
-		}
-
-		if ('string' === typeof arg || 'number' === typeof arg) {
-			classes.push(arg);
-		} else if ('object' === typeof arg) {
-			for (var key in arg) {
-				if (arg.hasOwnProperty(key) && arg[key]) {
-					classes.push(key);
-				}
-			}
-		}
+		checkArg(args[i]);
 	}
 	return classes.join(' ');
+
+	function checkArg(arg) {
+		if (!arg) {
+			return;
+		}
+
+		var x;
+		switch (Object.prototype.toString.call(arg).match(/(\w+)\]/)[1]) {
+			case 'String':
+			case 'Number':
+				classes.push(arg);
+				break;
+			case 'Array':
+				for (x = 0; x < arg.length; x++) {
+					checkArg(arg[x]);
+				}
+				break;
+			case 'Object':
+				for (x in arg) {
+					if (arg.hasOwnProperty(x) && arg[x]) {
+						classes.push(x);
+					}
+				}
+				break;
+		}
+	}
 }
 
 // safely export classNames in case the script is included directly on a page

--- a/tests.js
+++ b/tests.js
@@ -13,7 +13,7 @@ describe('classNames', function() {
     }), 'a f');
   });
 
-  it('joins arrays of class names and ignore falsy values', function() {
+  it('joins lists of class names and ignore falsy values', function() {
     assert.equal(classNames('a', 0, null, undefined, true, 1, 'b'), 'a 1 b');
   });
 
@@ -28,4 +28,33 @@ describe('classNames', function() {
   it('returns an empty string for an empty configuration', function() {
     assert.equal(classNames({}), '');
   });
+
+	it('supports an array of class names', function() {
+		assert.equal(classNames(['a', 'b']), 'a b');
+	});
+
+	it('joins array arguments with string arguments', function() {
+		assert.equal(classNames(['a', 'b'], 'c'), 'a b c');
+		assert.equal(classNames('c', ['a', 'b']), 'c a b');
+	});
+
+	it('handles multiple array arguments', function() {
+		assert.equal(classNames(['a', 'b'], ['c', 'd']), 'a b c d');
+	});
+
+	it('handles arrays that include falsy and true values', function() {
+		assert.equal(classNames(['a', 0, null, undefined, false, true, 'b']), 'a b');
+	});
+
+	it('handles arrays that include arrays', function() {
+		assert.equal(classNames(['a', ['b', 'c']]), 'a b c');
+	});
+
+	it('handles arrays that include objects', function() {
+		assert.equal(classNames(['a', {b: true, c: false}]), 'a b');
+	});
+
+	it('handles deep array recursion', function() {
+		assert.equal(classNames(['a', ['b', ['c', {d: true}]]]), 'a b c d');
+	});
 });


### PR DESCRIPTION
In case you are interested in accepting array arguments, as requested in https://github.com/JedWatson/classnames/issues/12, here's a PR that adds the functionality along with tests and a little documentation.

Instead of just inserting another `if` statement to `index.js` I made some significant revisions. If you don't like them, I can back out, of course. But my reasoning was that to get the intended functionality (recursive array checking) I needed (1) a named function that could be called recursively, and (2) a reliable way to test if an argument is an array. This PR uses an array-testing method I've seen some reliable people rely on, the one used by [lodash](https://github.com/lodash/lodash/blob/3.4.0/lodash.src.js#L8684) and [Underscore](http://underscorejs.org/docs/underscore.html#section-137); and since the method is equally useful to check the other types that needed checking, I thought I'd work in a simple switch statement.

Please let me know what you think, if you want anything changed, etc. Thanks! 

