### PR TITLE
Adds support for Arrays and Performance Improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,27 @@
 function classNames() {
-	var args = arguments;
-	var classes = [];
+	var classes = '';
+	var arg;
 
-	for (var i = 0; i < args.length; i++) {
-		var arg = args[i];
+	for (var i = 0; i < arguments.length; i++) {
+		arg = arguments[i];
 		if (!arg) {
 			continue;
 		}
 
 		if ('string' === typeof arg || 'number' === typeof arg) {
-			classes.push(arg);
+			classes += ' ' + arg;
+		} else if (Object.prototype.toString.call(arg) === '[object Array]') {
+			classes += ' ' + classNames.apply(null, arg);
 		} else if ('object' === typeof arg) {
 			for (var key in arg) {
-				if (arg.hasOwnProperty(key) && arg[key]) {
-					classes.push(key);
+				if (!arg.hasOwnProperty(key) || !arg[key]) {
+					continue;
 				}
+				classes += ' ' + key;
 			}
 		}
 	}
-	return classes.join(' ');
+	return classes.substr(1);
 }
 
 // safely export classNames in case the script is included directly on a page

--- a/tests.js
+++ b/tests.js
@@ -28,4 +28,33 @@ describe('classNames', function() {
   it('returns an empty string for an empty configuration', function() {
     assert.equal(classNames({}), '');
   });
+
+  it('supports an array of class names', function() {
+    assert.equal(classNames(['a', 'b']), 'a b');
+  });
+
+  it('joins array arguments with string arguments', function() {
+    assert.equal(classNames(['a', 'b'], 'c'), 'a b c');
+    assert.equal(classNames('c', ['a', 'b']), 'c a b');
+  });
+
+  it('handles multiple array arguments', function() {
+    assert.equal(classNames(['a', 'b'], ['c', 'd']), 'a b c d');
+  });
+
+  it('handles arrays that include falsy and true values', function() {
+    assert.equal(classNames(['a', 0, null, undefined, false, true, 'b']), 'a b');
+  });
+
+  it('handles arrays that include arrays', function() {
+    assert.equal(classNames(['a', ['b', 'c']]), 'a b c');
+  });
+
+  it('handles arrays that include objects', function() {
+    assert.equal(classNames(['a', {b: true, c: false}]), 'a b');
+  });
+
+  it('handles deep array recursion', function() {
+    assert.equal(classNames(['a', ['b', ['c', {d: true}]]]), 'a b c d');
+  });
 });


### PR DESCRIPTION
Here's another implementation to support Arrays. This also removes the use of Array#join in favor of String concatenation. [JSPerf] (http://jsperf.com/classnames-util/3)