### PR TITLE
Add support for camelCased keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ npm install classnames
 
 The `classNames` function takes any number of arguments which can be a string or object.
 The argument `'foo'` is short for `{foo: true}`. If the value of the key is falsy, it won't be included in the output.
+If an object key name is `camelCased`, it will be converted to `kebab-case`.
 
 ```js
 classNames('foo', 'bar'); // => 'foo bar'
 classNames('foo', { bar: true }); // => 'foo bar'
 classNames({ foo: true }, { bar: true }); // => 'foo bar'
 classNames({ foo: true, bar: true }); // => 'foo bar'
+classNames({fooBarBaz: true, bazQux: true}); // => 'foo-bar-baz baz-qux'
 
 // lots of arguments of various types
 classNames('foo', { bar: true, duck: false }, 'baz', { quux: true }) // => 'foo bar baz quux'

--- a/index.js
+++ b/index.js
@@ -17,7 +17,9 @@ function classNames() {
 				if (!arg.hasOwnProperty(key) || !arg[key]) {
 					continue;
 				}
-				classes += ' ' + key;
+				classes += ' ' + key.replace(/[A-Z]/g, function(l) {
+					return '-' + l.toLowerCase();
+				});
 			}
 		}
 	}

--- a/tests.js
+++ b/tests.js
@@ -33,6 +33,10 @@ describe('classNames', function() {
     assert.equal(classNames(['a', 'b']), 'a b');
   });
 
+  it('supports camelcased keys', function() {
+    assert.equal(classNames({fooBarBaz: true}), 'foo-bar-baz');
+  });
+
   it('joins array arguments with string arguments', function() {
     assert.equal(classNames(['a', 'b'], 'c'), 'a b c');
     assert.equal(classNames('c', ['a', 'b']), 'c a b');


### PR DESCRIPTION
Converts `camelCase` key names to `kebab-case`. Example:

```js
classNames({fooBarBaz: true, bazQux: true}); // => 'foo-bar-baz baz-qux'
```