### PR TITLE
Add support for custom toString implementations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 function classNames() {
 	var classes = '';
+	var argClasses;
 	var arg;
 
 	for (var i = 0; i < arguments.length; i++) {
@@ -13,11 +14,16 @@ function classNames() {
 		} else if (Object.prototype.toString.call(arg) === '[object Array]') {
 			classes += ' ' + classNames.apply(null, arg);
 		} else if ('object' === typeof arg) {
-			for (var key in arg) {
-				if (!arg.hasOwnProperty(key) || !arg[key]) {
-					continue;
+			argClasses = arg.toString();
+			if (argClasses === '[object Object]') {
+				for (var key in arg) {
+					if (!arg.hasOwnProperty(key) || !arg[key]) {
+						continue;
+					}
+					classes += ' ' + key;
 				}
-				classes += ' ' + key;
+			} else {
+				classes += ' ' + argClasses;
 			}
 		}
 	}

--- a/tests.js
+++ b/tests.js
@@ -57,4 +57,15 @@ describe('classNames', function() {
   it('handles deep array recursion', function() {
     assert.equal(classNames(['a', ['b', ['c', {d: true}]]]), 'a b c d');
   });
+  
+  it('handles customized toString results', function() {
+    function custom(output) {
+      function customOutput() {}
+      customOutput.prototype.toString = function() {
+        return output;
+      }
+      return new customOutput();
+    }
+    assert.equal(classNames(custom('a')), 'a');
+  });
 });


### PR DESCRIPTION
Checking for results of `toString()` makes it possible to use more complicated tools together with classNames, for example ones that specialize in BEM.

This will have some impact to performance, but only with objects and the addition is only one string comparison and a `toString` call.