### PR TITLE
use [].join over concatenation

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@
 	var hasOwn = {}.hasOwnProperty;
 
 	function classNames () {
-		var classes = '';
+		var classes = [];
 
 		for (var i = 0; i < arguments.length; i++) {
 			var arg = arguments[i];
@@ -20,19 +20,19 @@
 			var argType = typeof arg;
 
 			if (argType === 'string' || argType === 'number') {
-				classes += ' ' + arg;
+				classes.push(arg);
 			} else if (Array.isArray(arg)) {
-				classes += ' ' + classNames.apply(null, arg);
+				classes.push(classNames.apply(null, arg));
 			} else if (argType === 'object') {
 				for (var key in arg) {
 					if (hasOwn.call(arg, key) && arg[key]) {
-						classes += ' ' + key;
+						classes.push(key);
 					}
 				}
 			}
 		}
 
-		return classes.substr(1);
+		return classes.join(' ');
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
A rebase of #36.

Using node `v4.1.1`:

``` javascript
* local#strings x 6,045,951 ops/sec ±1.58% (97 runs sampled)
*   npm#strings x 3,216,399 ops/sec ±4.18% (88 runs sampled)

> Fastest is local#strings

* local#object x 2,542,831 ops/sec ±1.06% (98 runs sampled)
*   npm#object x 2,526,207 ops/sec ±1.12% (91 runs sampled)

> Fastest is local#object |   npm#object

* local#mix x 948,129 ops/sec ±1.53% (93 runs sampled)
*   npm#mix x 1,265,072 ops/sec ±0.97% (96 runs sampled)

> Fastest is npm#mix

* local#arrays x 623,087 ops/sec ±0.69% (98 runs sampled)
*   npm#arrays x 814,812 ops/sec ±0.69% (103 runs sampled)

> Fastest is npm#arrays
```

Performance TL;DR:
* pure string case is 180% faster
* objects are the same
* (string, object), arrays and multiple objects (mix) are all 25% slower

Its a trade off,  I'd wager the two most important cases are the pure string and (string, object) cases,  in which case I'm still not sure what the decision should be.

Perhaps some results from other engines could be the deciding factor?  @impinball 