### PR TITLE
Update readme to include string key in object notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The argument `'foo'` is short for `{ foo: true }`. If the value of the key is fa
 ```js
 classNames('foo', 'bar'); // => 'foo bar'
 classNames('foo', { bar: true }); // => 'foo bar'
+classNames({'foo-bar': true}); // => 'foo-bar'
 classNames({ foo: true }, { bar: true }); // => 'foo bar'
 classNames({ foo: true, bar: true }); // => 'foo bar'
 


### PR DESCRIPTION
It's not immediately obvious that a string can be used as a key in the readme object notation example .  Further, trying to use a hyphen in a key that _isn't_ a string can cause all sorts of unwelcome stuff.  So I thought it'd be beneficial to add this.