### PR TITLE
Return undefined for empty configurations

### DIFF
--- a/bind.js
+++ b/bind.js
@@ -32,7 +32,7 @@
 			}
 		}
 
-		return classes.join(' ');
+		return classes[0] && classes.join(' ');
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {

--- a/dedupe.js
+++ b/dedupe.js
@@ -79,7 +79,7 @@
 				}
 			}
 
-			return list.join(' ');
+			return list[0] && list.join(' ');
 		}
 
 		return _classNames;

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@
 			}
 		}
 
-		return classes.join(' ');
+		return classes[0] && classes.join(' ');
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {

--- a/tests/bind.js
+++ b/tests/bind.js
@@ -39,8 +39,8 @@ describe('bind', function () {
 			assert.equal(classNames('', 'b', {}, ''), 'b');
 		});
 
-		it('returns an empty string for an empty configuration', function () {
-			assert.equal(classNames({}), '');
+		it('returns undefined for an empty configuration', function () {
+			assert.equal(classNames({}), undefined);
 		});
 
 		it('supports an array of class names', function () {
@@ -109,8 +109,8 @@ describe('bind', function () {
 			assert.equal(classNamesBound('', 'b', {}, ''), '#b');
 		});
 
-		it('returns an empty string for an empty configuration', function () {
-			assert.equal(classNamesBound({}), '');
+		it('returns undefined for an empty configuration', function () {
+			assert.equal(classNamesBound({}), undefined);
 		});
 
 		it('supports an array of class names', function () {

--- a/tests/dedupe.js
+++ b/tests/dedupe.js
@@ -42,8 +42,8 @@ describe('dedupe', function () {
 		assert.equal(dedupe('', 'b', {}, ''), 'b');
 	});
 
-	it('returns an empty string for an empty configuration', function () {
-		assert.equal(dedupe({}), '');
+	it('returns undefined for an empty configuration', function () {
+		assert.equal(dedupe({}), undefined);
 	});
 
 	it('supports an array of class names', function () {

--- a/tests/index.js
+++ b/tests/index.js
@@ -27,8 +27,8 @@ describe('classNames', function () {
 		assert.equal(classNames('', 'b', {}, ''), 'b');
 	});
 
-	it('returns an empty string for an empty configuration', function () {
-		assert.equal(classNames({}), '');
+	it('returns undefined for an empty configuration', function () {
+		assert.equal(classNames({}), undefined);
 	});
 
 	it('supports an array of class names', function () {


### PR DESCRIPTION
I found that smatterings of `className=""` in the dev tools was a bit messy, so I began using `className={classNames(...) || void 0}` to keep empty strings out of the DOM.

This would hypothetically be a breaking change if anyone uses `className={'abc ' + classNames(...)}`. Given that defeats the purpose of the utility I'd venture a guess it's not worth considering.

I have no idea how to use jsPerf (obviously I'm not a JS guy) but here are the benchmark results:
### Before

```
* local#strings x 6,992,872 ops/sec ±1.18% (96 runs sampled)
*   npm#strings x 6,784,634 ops/sec ±1.15% (90 runs sampled)
* local/dedupe#strings x 644,292 ops/sec ±1.05% (93 runs sampled)
*   npm/dedupe#strings x 638,116 ops/sec ±1.35% (91 runs sampled)

> Fastest is local#strings

* local#object x 2,604,385 ops/sec ±1.30% (92 runs sampled)
*   npm#object x 2,343,371 ops/sec ±4.28% (83 runs sampled)
* local/dedupe#object x 955,044 ops/sec ±1.14% (92 runs sampled)
*   npm/dedupe#object x 960,496 ops/sec ±1.89% (89 runs sampled)

> Fastest is local#object

* local#strings, object x 2,815,902 ops/sec ±2.65% (87 runs sampled)
*   npm#strings, object x 2,882,716 ops/sec ±1.57% (92 runs sampled)
* local/dedupe#strings, object x 610,242 ops/sec ±1.26% (95 runs sampled)
*   npm/dedupe#strings, object x 600,369 ops/sec ±1.22% (91 runs sampled)

> Fastest is npm#strings, object | local#strings, object

* local#mix x 942,637 ops/sec ±1.29% (90 runs sampled)
*   npm#mix x 948,050 ops/sec ±1.34% (89 runs sampled)
* local/dedupe#mix x 299,792 ops/sec ±1.27% (92 runs sampled)
*   npm/dedupe#mix x 299,648 ops/sec ±1.35% (88 runs sampled)

> Fastest is npm#mix | local#mix

* local#arrays x 638,631 ops/sec ±1.34% (89 runs sampled)
*   npm#arrays x 617,121 ops/sec ±1.08% (91 runs sampled)
* local/dedupe#arrays x 312,149 ops/sec ±1.21% (91 runs sampled)
*   npm/dedupe#arrays x 323,669 ops/sec ±1.19% (95 runs sampled)

> Fastest is local#arrays
```
### After

```
* local#strings x 6,876,549 ops/sec ±0.99% (94 runs sampled)
*   npm#strings x 6,869,830 ops/sec ±1.12% (97 runs sampled)
* local/dedupe#strings x 655,405 ops/sec ±0.96% (93 runs sampled)
*   npm/dedupe#strings x 659,649 ops/sec ±0.93% (94 runs sampled)

> Fastest is local#strings |   npm#strings

* local#object x 2,708,574 ops/sec ±1.35% (94 runs sampled)
*   npm#object x 2,750,012 ops/sec ±1.03% (96 runs sampled)
* local/dedupe#object x 953,223 ops/sec ±1.02% (95 runs sampled)
*   npm/dedupe#object x 988,905 ops/sec ±0.99% (91 runs sampled)

> Fastest is npm#object | local#object

* local#strings, object x 3,020,787 ops/sec ±1.06% (94 runs sampled)
*   npm#strings, object x 2,984,489 ops/sec ±1.12% (96 runs sampled)
* local/dedupe#strings, object x 624,422 ops/sec ±1.41% (94 runs sampled)
*   npm/dedupe#strings, object x 632,039 ops/sec ±0.93% (95 runs sampled)

> Fastest is local#strings, object |   npm#strings, object

* local#mix x 1,031,081 ops/sec ±1.13% (95 runs sampled)
*   npm#mix x 1,042,454 ops/sec ±1.02% (95 runs sampled)
* local/dedupe#mix x 319,174 ops/sec ±1.10% (96 runs sampled)
*   npm/dedupe#mix x 317,444 ops/sec ±1.40% (92 runs sampled)

> Fastest is npm#mix | local#mix

* local#arrays x 664,667 ops/sec ±1.13% (96 runs sampled)
*   npm#arrays x 673,983 ops/sec ±1.04% (94 runs sampled)
* local/dedupe#arrays x 318,820 ops/sec ±0.95% (95 runs sampled)
*   npm/dedupe#arrays x 322,031 ops/sec ±1.03% (94 runs sampled)

> Fastest is npm#arrays
```
