### PR TITLE
Prefix numeric classnames with underscore

### DIFF
--- a/bind.js
+++ b/bind.js
@@ -19,8 +19,10 @@
 
 			var argType = typeof arg;
 
-			if (argType === 'string' || argType === 'number') {
+			if (argType === 'string') {
 				classes.push(this && this[arg] || arg);
+			} else if (argType === 'number') {
+				classes.push(this && this['_' + arg] || '_' + arg);
 			} else if (Array.isArray(arg)) {
 				classes.push(classNames.apply(this, arg));
 			} else if (argType === 'object') {

--- a/dedupe.js
+++ b/dedupe.js
@@ -20,7 +20,7 @@
 		var hasOwn = {}.hasOwnProperty;
 
 		function _parseNumber (resultSet, num) {
-			resultSet[num] = true;
+			resultSet['_' + num] = true;
 		}
 
 		function _parseObject (resultSet, object) {

--- a/index.js
+++ b/index.js
@@ -19,8 +19,10 @@
 
 			var argType = typeof arg;
 
-			if (argType === 'string' || argType === 'number') {
+			if (argType === 'string') {
 				classes.push(arg);
+			} else if (argType === 'number') {
+				classes.push('_' + arg);
 			} else if (Array.isArray(arg)) {
 				classes.push(classNames.apply(null, arg));
 			} else if (argType === 'object') {

--- a/tests/bind.js
+++ b/tests/bind.js
@@ -28,7 +28,7 @@ describe('bind', function () {
 		});
 
 		it('joins arrays of class names and ignore falsy values', function () {
-			assert.equal(classNames('a', 0, null, undefined, true, 1, 'b'), 'a 1 b');
+			assert.equal(classNames('a', 0, null, undefined, true, 1, 'b'), 'a _1 b');
 		});
 
 		it('supports heterogenous arguments', function () {
@@ -98,7 +98,7 @@ describe('bind', function () {
 			}), '#a #f x z');
 		})
 		it('joins arrays of class names and ignore falsy values', function () {
-			assert.equal(classNamesBound('a', 0, null, undefined, true, 1, 'b'), '#a 1 #b');
+			assert.equal(classNamesBound('a', 0, null, undefined, true, 1, 'b'), '#a _1 #b');
 		});
 
 		it('supports heterogenous arguments', function () {

--- a/tests/dedupe.js
+++ b/tests/dedupe.js
@@ -24,14 +24,14 @@ describe('dedupe', function () {
 	});
 
 	it('should make sure object with falsy value wipe out previous classes', function () {
-		assert.equal(dedupe('foo foo', 0, null, undefined, true, 1, 'b', { 'foo': false }), '1 b');
+		assert.equal(dedupe('foo foo', 0, null, undefined, true, 1, 'b', { 'foo': false }), '_1 b');
 		assert.equal(dedupe('foo', 'foobar', 'bar', { foo: false }), 'foobar bar');
 		assert.equal(dedupe('foo', 'foo-bar', 'bar', { foo: false }), 'foo-bar bar');
 		assert.equal(dedupe('foo', '-moz-foo-bar', 'bar', { foo: false }), '-moz-foo-bar bar');
 	});
 
 	it('joins arrays of class names and ignore falsy values', function () {
-		assert.equal(dedupe('a', 0, null, undefined, true, 1, 'b'), '1 a b');
+		assert.equal(dedupe('a', 0, null, undefined, true, 1, 'b'), 'a _1 b');
 	});
 
 	it('supports heterogenous arguments', function () {

--- a/tests/index.js
+++ b/tests/index.js
@@ -16,7 +16,7 @@ describe('classNames', function () {
 	});
 
 	it('joins arrays of class names and ignore falsy values', function () {
-		assert.equal(classNames('a', 0, null, undefined, true, 1, 'b'), 'a 1 b');
+		assert.equal(classNames('a', 0, null, undefined, true, 1, 'b'), 'a _1 b');
 	});
 
 	it('supports heterogenous arguments', function () {


### PR DESCRIPTION
The naming rule for css classes is `-?[_a-zA-Z]+[_a-zA-Z0-9-]*`
As a convenience this will prefix a number with `_` instead of throwing or logging a warning.
