### PR TITLE
Improve dedupe version performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ var btnClass = classNames('btn', this.props.className, {
 
 There is an alternate version of `classNames` available which correctly dedupes classes and ensures that falsy classes specified in later arguments are excluded from the result set.
 
-This version is slower (about 10x) so it is offered as an opt-in.
+This version is slower (about 5x) so it is offered as an opt-in.
 
 To use the dedupe version with node, browserify or webpack:
 

--- a/dedupe.js
+++ b/dedupe.js
@@ -76,13 +76,15 @@
 				args[i] = arguments[i];
 			}
 
-			var classSet = {};
+			// don't inherit from Object so we can skip hasOwnProperty check later
+			// http://stackoverflow.com/questions/15518328/creating-js-object-with-object-createnull#answer-21079232
+			var classSet = Object.create(null);
 			_parseArray(classSet, args);
 
 			var list = [];
 
 			for (var k in classSet) {
-				if (hasOwn.call(classSet, k) && classSet[k]) {
+				if (classSet[k]) {
 					list.push(k)
 				}
 			}

--- a/dedupe.js
+++ b/dedupe.js
@@ -68,8 +68,16 @@
 		}
 
 		function _classNames () {
+			// don't leak arguments
+			// https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
+			var len = arguments.length;
+			var args = Array(len);
+			for (var i = 0; i < len; i++) {
+				args[i] = arguments[i];
+			}
+
 			var classSet = {};
-			_parseArray(classSet, arguments);
+			_parseArray(classSet, args);
 
 			var list = [];
 

--- a/dedupe.js
+++ b/dedupe.js
@@ -26,11 +26,9 @@
 		function _parseObject (resultSet, object) {
 			for (var k in object) {
 				if (hasOwn.call(object, k)) {
-					if (object[k]) {
-						resultSet[k] = true;
-					} else {
-						delete resultSet[k];
-					}
+					// set value to false instead of deleting it to avoid changing object structure
+					// https://www.smashingmagazine.com/2012/11/writing-fast-memory-efficient-javascript/#de-referencing-misconceptions
+					resultSet[k] = !!object[k];
 				}
 			}
 		}


### PR DESCRIPTION
Here are benchmark results:
```
> classnames@2.2.3 benchmarks /home/ja/code/classnames
> node ./benchmarks/run

* local#strings x 5,636,517 ops/sec ±0.44% (101 runs sampled)
*   npm#strings x 5,630,325 ops/sec ±0.57% (99 runs sampled)
* local/dedupe#strings x 902,229 ops/sec ±1.89% (91 runs sampled)
*   npm/dedupe#strings x 463,660 ops/sec ±0.47% (98 runs sampled)

> Fastest is local#strings |   npm#strings

* local#object x 2,655,968 ops/sec ±0.54% (98 runs sampled)
*   npm#object x 2,676,877 ops/sec ±0.17% (101 runs sampled)
* local/dedupe#object x 1,721,874 ops/sec ±0.64% (96 runs sampled)
*   npm/dedupe#object x 826,229 ops/sec ±0.52% (94 runs sampled)

> Fastest is npm#object | local#object

* local#strings, object x 2,895,452 ops/sec ±0.51% (99 runs sampled)
*   npm#strings, object x 2,933,864 ops/sec ±0.23% (102 runs sampled)
* local/dedupe#strings, object x 849,459 ops/sec ±0.69% (95 runs sampled)
*   npm/dedupe#strings, object x 451,350 ops/sec ±0.22% (101 runs sampled)

> Fastest is npm#strings, object

* local#mix x 850,158 ops/sec ±2.27% (99 runs sampled)
*   npm#mix x 849,324 ops/sec ±1.67% (98 runs sampled)
* local/dedupe#mix x 287,635 ops/sec ±0.29% (100 runs sampled)
*   npm/dedupe#mix x 207,364 ops/sec ±0.18% (99 runs sampled)

> Fastest is npm#mix

* local#arrays x 633,765 ops/sec ±0.34% (102 runs sampled)
*   npm#arrays x 549,266 ops/sec ±0.27% (102 runs sampled)
* local/dedupe#arrays x 277,621 ops/sec ±0.42% (100 runs sampled)
*   npm/dedupe#arrays x 256,326 ops/sec ±0.20% (101 runs sampled)

> Fastest is local#arrays
```

So now we're about 2 times faster (on v8 at least).