### PR TITLE
improve dedupe perf

### DIFF
--- a/dedupe.js
+++ b/dedupe.js
@@ -9,6 +9,11 @@
 	'use strict';
 
 	var classNames = (function () {
+		// don't inherit from Object so we can skip hasOwnProperty check later
+		// http://stackoverflow.com/questions/15518328/creating-js-object-with-object-createnull#answer-21079232
+		function StorageObject() {}
+		StorageObject.prototype = Object.create(null);
+
 		function _parseArray (resultSet, array) {
 			var length = array.length;
 
@@ -74,9 +79,7 @@
 				args[i] = arguments[i];
 			}
 
-			// don't inherit from Object so we can skip hasOwnProperty check later
-			// http://stackoverflow.com/questions/15518328/creating-js-object-with-object-createnull#answer-21079232
-			var classSet = Object.create(null);
+			var classSet = new StorageObject();
 			_parseArray(classSet, args);
 
 			var list = [];


### PR DESCRIPTION
Creating instances with `new` of an object that inherits from `Object.create(null)` is faster than creating an object with `Object.create(null)` over-and-over.

```
$ npm run benchmarks

> classnames@2.2.4 benchmarks /Users/asuarez/src/classnames
> node ./benchmarks/run

* local#strings x 7,708,933 ops/sec ±0.77% (96 runs sampled)
*   npm#strings x 7,653,876 ops/sec ±0.70% (96 runs sampled)
* local/dedupe#strings x 1,367,787 ops/sec ±0.70% (97 runs sampled)
*   npm/dedupe#strings x 1,202,487 ops/sec ±0.56% (96 runs sampled)

> Fastest is local#strings |   npm#strings

* local#object x 2,919,114 ops/sec ±0.78% (98 runs sampled)
*   npm#object x 2,904,197 ops/sec ±0.72% (100 runs sampled)
* local/dedupe#object x 2,386,335 ops/sec ±0.92% (93 runs sampled)
*   npm/dedupe#object x 1,893,136 ops/sec ±0.79% (97 runs sampled)

> Fastest is local#object |   npm#object

* local#strings, object x 3,136,702 ops/sec ±1.58% (99 runs sampled)
*   npm#strings, object x 3,156,282 ops/sec ±0.77% (98 runs sampled)
* local/dedupe#strings, object x 1,340,740 ops/sec ±1.07% (96 runs sampled)
*   npm/dedupe#strings, object x 1,149,586 ops/sec ±2.20% (95 runs sampled)

> Fastest is npm#strings, object | local#strings, object

* local#mix x 1,129,619 ops/sec ±2.40% (95 runs sampled)
*   npm#mix x 1,127,121 ops/sec ±2.39% (89 runs sampled)
* local/dedupe#mix x 491,806 ops/sec ±2.55% (95 runs sampled)
*   npm/dedupe#mix x 476,373 ops/sec ±2.76% (92 runs sampled)

> Fastest is local#mix |   npm#mix

* local#arrays x 706,011 ops/sec ±1.59% (98 runs sampled)
*   npm#arrays x 703,220 ops/sec ±2.14% (95 runs sampled)
* local/dedupe#arrays x 416,208 ops/sec ±2.61% (94 runs sampled)
*   npm/dedupe#arrays x 404,127 ops/sec ±1.98% (97 runs sampled)

> Fastest is local#arrays |   npm#arrays
```