### PR TITLE
Improve performance in 2 times

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,28 +11,28 @@
 	var hasOwn = {}.hasOwnProperty;
 
 	function classNames () {
-		var classes = [];
+		var res = '';
 
-		for (var i = 0; i < arguments.length; i++) {
+		for (var i = 0, len = arguments.length; i < len; i++) {
 			var arg = arguments[i];
 			if (!arg) continue;
 
 			var argType = typeof arg;
 
 			if (argType === 'string' || argType === 'number') {
-				classes.push(arg);
+				res += arg + ' ';
 			} else if (Array.isArray(arg)) {
-				classes.push(classNames.apply(null, arg));
+				res += classNames.apply(null, arg) + ' ';
 			} else if (argType === 'object') {
 				for (var key in arg) {
 					if (hasOwn.call(arg, key) && arg[key]) {
-						classes.push(key);
+						res += key + ' ';
 					}
 				}
 			}
 		}
 
-		return classes.join(' ');
+		return res.trim();
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
**How**:
- use string intead of array
- cache arguments.length

**Benchmark**:
```
$ node -v
v6.2.2

$ npm run benchmarks

> classnames@2.2.5 benchmarks /Users/aleksey/code/experiments/classnames
> node ./benchmarks/run

* local#strings x 1,716,748 ops/sec ±10.68% (80 runs sampled)
*   npm#strings x 804,827 ops/sec ±1.05% (92 runs sampled)
* local/dedupe#strings x 291,698 ops/sec ±3.52% (87 runs sampled)
*   npm/dedupe#strings x 300,405 ops/sec ±6.53% (87 runs sampled)

> Fastest is local#strings

* local#object x 1,278,203 ops/sec ±4.31% (90 runs sampled)
*   npm#object x 588,600 ops/sec ±1.58% (88 runs sampled)
* local/dedupe#object x 472,073 ops/sec ±0.66% (96 runs sampled)
*   npm/dedupe#object x 450,313 ops/sec ±1.60% (93 runs sampled)

> Fastest is local#object

* local#strings, object x 1,230,869 ops/sec ±0.89% (95 runs sampled)
*   npm#strings, object x 583,617 ops/sec ±2.05% (92 runs sampled)
* local/dedupe#strings, object x 254,245 ops/sec ±0.92% (95 runs sampled)
*   npm/dedupe#strings, object x 211,184 ops/sec ±7.14% (81 runs sampled)

> Fastest is local#strings, object

* local#mix x 508,282 ops/sec ±11.10% (74 runs sampled)
*   npm#mix x 346,792 ops/sec ±9.73% (80 runs sampled)
* local/dedupe#mix x 59,928 ops/sec ±16.01% (72 runs sampled)
*   npm/dedupe#mix x 44,578 ops/sec ±14.48% (57 runs sampled)

> Fastest is local#mix

* local#arrays x 321,436 ops/sec ±9.90% (91 runs sampled)
*   npm#arrays x 125,608 ops/sec ±8.53% (75 runs sampled)
* local/dedupe#arrays x 138,630 ops/sec ±3.89% (95 runs sampled)
*   npm/dedupe#arrays x 103,878 ops/sec ±9.44% (72 runs sampled)

> Fastest is local#arrays
```