### PR TITLE
test configs: use standard testing pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,3 @@ node_js:
   - "6"
   - "0.10"
   - "0.12"
-env:
-  - TEST_SUITE=unit
-script: "npm run-script $TEST_SUITE"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "scripts": {
     "benchmarks": "node ./benchmarks/run",
-    "unit": "mocha tests/*.js",
-    "test": "npm run unit"
+    "test": "mocha tests/*.js"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
Instead of doing `npm run unit`, just configure it in a way that we can run `npm test`. This simplifies both `package.json` and `.travis.yml`
