### PR TITLE
Supports react class with variables css modules resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,11 +24,17 @@
 			} else if (Array.isArray(arg)) {
 				classes.push(classNames.apply(null, arg));
 			} else if (argType === 'object') {
-				for (var key in arg) {
-					if (hasOwn.call(arg, key) && arg[key]) {
-						classes.push(key);
-					}
-				}
+				if ('classname' in arg && 'display' in arg) {
+                    if (hasOwn.call(arg, 'display') && arg['classname']) {
+                        classArr.push(arg['classname']);
+                    }
+                } else {
+                    for (var key in arg) {
+                        if (hasOwn.call(arg, key) && arg[key]) {
+                            classArr.push(key);
+                        }
+                    }
+                }
 			}
 		}
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -59,4 +59,80 @@ describe('classNames', function () {
 	it('handles deep array recursion', function () {
 		assert.equal(classNames(['a', ['b', ['c', {d: true}]]]), 'a b c d');
 	});
+
+	it('handles with variable array', function() {
+        var classNames1 = 'a',
+            classNames2 = 'b',
+            classNames3 = 'c',
+            classNames4 = 'd';
+        assert.equal(classNames([{
+            'classname': classNames1,
+            'display': true
+        }, {
+            'classname': classNames2,
+            'display': true
+        }, {
+            'classname': classNames3,
+            'display': false
+        }, {
+            'classname': classNames4,
+            'display': true
+        }]), 'a b d');
+    });
+
+    it('handle with variable array of objects and string', function() {
+        var classNames1 = 'a',
+            classNames2 = 'b',
+            classNames3 = 'c',
+            classNames4 = 'd';
+        assert.equal(classNames([{
+            'classname': classNames1,
+            'display': true
+        }, {
+            'classname': classNames2,
+            'display': true
+        }, {
+            'classname': classNames3,
+            'display': false
+        }, 'd']), 'a b d');
+    });
+
+    it('handle with arrays and array with variable objects', function() {
+        var classNames1 = 'a',
+            classNames2 = 'b',
+            classNames3 = 'c',
+            classNames4 = 'd';
+        assert.equal(classNames([{
+                'classname': classNames1,
+                'display': true
+            }, {
+                'classname': classNames2,
+                'display': true
+            }, {
+                'classname': classNames3,
+                'display': false
+            },
+            ['d']
+        ]), 'a b d');
+    });
+
+    it('handle double with variable array of objects', function() {
+        var classNames1 = 'a',
+            classNames2 = 'b',
+            classNames3 = 'c',
+            classNames4 = 'd';
+        assert.equal(classNames([{
+            'classname': classNames1,
+            'display': true
+        }, {
+            'classname': classNames2,
+            'display': true
+        }], [{
+            'classname': classNames3,
+            'display': false
+        }, {
+            'classname': classNames4,
+            'display': true
+        }]), 'a b d');
+    });
 });


### PR DESCRIPTION
When using react, there will be a problem, plug-in and can not support the use of variables in the object, the authors hope to see, plus the support, thank you!

For example:

If I want use variables

```js
let classNames1 = 'class1';
let classNames2 = 'class2';
let classNames3 = 'class3';

reactClass([{
    classNames1: true,
    classNames2: false,
    classNames3: true
}]) // => 'classNames1 classNames3'
```
so I edit the code,it can use like below:
```js
let classNames1 = 'class1';
let classNames2 = 'class2';
let classNames3 = 'class3';

reactClass([{
    'classname': classNames1,
    'display': true
}, {
    'classname': classNames2,
    'display': false
}, {
    'classname': classNames3,
    'display': true
}]) // => 'class1 class3'
```