### PR TITLE
Exclude bower.json and docs from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,6 @@
 /.*
 /benchmarks/
 /tests/
+/bower.json
+/CONTRIBUTING.md
+/HISTORY.md


### PR DESCRIPTION
Another option would be to add a `files` array to package.json.