### PR TITLE
explicitly test assumptions about all types of truthy and falsy property values

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -59,4 +59,27 @@ describe('classNames', function () {
 	it('handles deep array recursion', function () {
 		assert.equal(classNames(['a', ['b', ['c', {d: true}]]]), 'a b c d');
 	});
+
+	it('handles all types of truthy and falsy property values as expected', function () {
+		assert.equal(classNames({
+			// falsy:
+			null: null,
+			emptyString: "",
+			noNumber: NaN,
+			zero: 0,
+			negativeZero: -0,
+			false: false,
+			undefined: undefined,
+
+			// truthy (literally anything else):
+			nonEmptyString: "foobar",
+			whitespace: ' ',
+			function: Object.prototype.toString,
+			emptyObject: {},
+			nonEmptyObject: {a: 1, b: 2},
+			emptyList: [],
+			nonEmptyList: [1, 2, 3],
+			greaterZero: 1
+		}), 'nonEmptyString whitespace function emptyObject nonEmptyObject emptyList nonEmptyList greaterZero')
+	})
 });


### PR DESCRIPTION
Nothing terribly important, but I added the test to test some assumptions after discovering that in the TypeScript definition "ClassDictionary" only allowed boolean values for property values passed into classNames.