### PR TITLE
classnames working with arguments object

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,13 +12,12 @@
 
 	function classNames () {
 		var classes = [];
-
-		for (var i = 0; i < arguments.length; i++) {
-			var arg = arguments[i];
+		var args = Array.prototype.slice.call(arguments, 0)
+		for (var i = 0; i < args.length; i++) {
+			var arg = args[i];
 			if (!arg) continue;
-
+			if (arg.callee) arg = Array.from(arg);
 			var argType = typeof arg;
-
 			if (argType === 'string' || argType === 'number') {
 				classes.push(arg);
 			} else if (Array.isArray(arg)) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -59,4 +59,22 @@ describe('classNames', function () {
 	it('handles deep array recursion', function () {
 		assert.equal(classNames(['a', ['b', ['c', {d: true}]]]), 'a b c d');
 	});
+
+	it('handles arguments array', function () {
+		var func = function(a, b, c) { return classNames(arguments) }
+		assert.equal(func('a', 'b', 'c'), 'a b c');
+	});
+
+	it('handles deep arguments array', function () {
+		var func = function(a, b, c) { return classNames(arguments) }
+		assert.equal(classNames([func('a', 'b', 'c'), 'd']), 'a b c d');
+	});
+
+	it('handles arguments that include objects', function () {
+		var func = function(a, b, c) { return classNames(arguments) }
+		assert.equal(func('a', {b: true, c: false}), 'a b');
+	});
+
+
+
 });


### PR DESCRIPTION
If we will use `classnames` with `arguments` object inside a function we get strange behavior
```javascript
var func = function(a, b, c) { 
  return classnames(arguments)
}

func("a", "b", "c"); // => "0 1 2"

```