### PR TITLE
Adding join method

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,37 @@ export default class SubmitButton extends Component {
 
 ```
 
+### Alternate `join` version (for [css-modules](https://github.com/css-modules/css-modules))
+
+If you are using [css-modules](https://github.com/css-modules/css-modules), or a similar approach to abstract class "names" and the real `className` values that are actually output to the DOM, and you have multiple sources for classNames, you may want to use the `join` variant.
+
+_Note that in ES2015 environments, it may be better to use the "dynamic class names" approach documented above._
+
+```js
+var classNames = require('classnames/bind');
+
+var styles1 = {
+  foo: 'abc',
+  bar: 'def',
+  baz: 'xyz'
+};
+
+var styles2 = {
+	qux: 'ghi',
+	quz: 'jkl',
+	quuz: 'uvw',
+}
+
+var cx = classNames.join(styles1, styles2);
+
+var className = cx('foo', 'bar', ['qux', 'quz'], { baz: true, quuz: true }); // => "abc def ghi jkl uvw xyz"
+```
 
 ## Polyfills needed to support older browsers
+
+#### `classNames >=2.3.0`
+
+`Object.assign`: see [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) for details about unsupported older browsers (e.g. <= IE) and a simple polyfill. This is only used in `bind.js`, using `join` variant.
 
 #### `classNames >=2.0.0`
 

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -1,6 +1,16 @@
 var fixtures = require('./fixtures');
+var cssModule = {
+	'one': 'one',
+	'two': 'two',
+	'three': 'three',
+	'four': 'four',
+	'five': 'five',
+	'six': 'six'
+};
+
 var local = require('../');
 var dedupe = require('../dedupe');
+var bind = require('../bind').bind(cssModule);
 var localPackage = require('../package.json');
 
 function log (message) {
@@ -10,6 +20,7 @@ function log (message) {
 try {
 	var npm = require('classnames');
 	var npmDedupe = require('classnames/dedupe');
+	var npmBind = require('classnames/bind').bind(cssModule);
 	var npmPackage = require('./node_modules/classnames/package.json');
 } catch (e) {
 	log('There was an error loading the benchmark classnames package.\n' +
@@ -28,6 +39,6 @@ var runChecks = require('./runChecks');
 var runSuite = require('./runSuite');
 
 fixtures.forEach(function (f) {
-	runChecks(local, npm, dedupe, npmDedupe, f);
-	runSuite(local, npm, dedupe, npmDedupe, f, log);
+	runChecks(local, npm, dedupe, npmDedupe, bind, npmBind, f);
+	runSuite(local, npm, dedupe, npmDedupe, bind, npmBind, f, log);
 });

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -7,10 +7,21 @@ var cssModule = {
 	'five': 'five',
 	'six': 'six'
 };
+var cssModule1 = {
+	'one': 'one',
+	'two': 'two',
+	'three': 'three'
+}
+var cssModule2 = {
+	'four': 'four',
+	'five': 'five',
+	'six': 'six'
+};
 
 var local = require('../');
 var dedupe = require('../dedupe');
 var bind = require('../bind').bind(cssModule);
+var join = require('../bind').join(cssModule1, cssModule2);
 var localPackage = require('../package.json');
 
 function log (message) {
@@ -39,6 +50,6 @@ var runChecks = require('./runChecks');
 var runSuite = require('./runSuite');
 
 fixtures.forEach(function (f) {
-	runChecks(local, npm, dedupe, npmDedupe, bind, npmBind, f);
-	runSuite(local, npm, dedupe, npmDedupe, bind, npmBind, f, log);
+	runChecks(local, npm, dedupe, npmDedupe, bind, npmBind, join, f);
+	runSuite(local, npm, dedupe, npmDedupe, bind, npmBind, join, f, log);
 });

--- a/benchmarks/runChecks.js
+++ b/benchmarks/runChecks.js
@@ -4,7 +4,7 @@ function sortClasses (str) {
 	return str.split(' ').sort().join(' ');
 }
 
-function runChecks (local, npm, dedupe, npmDedupe, bind, npmBind, fixture) {
+function runChecks (local, npm, dedupe, npmDedupe, bind, npmBind, join, fixture) {
 	// sort assertions because dedupe returns results in a different order
 	assert.equal(sortClasses(local.apply(null, fixture.args)), sortClasses(fixture.expected));
 	assert.equal(sortClasses(dedupe.apply(null, fixture.args)), sortClasses(fixture.expected));
@@ -12,6 +12,7 @@ function runChecks (local, npm, dedupe, npmDedupe, bind, npmBind, fixture) {
 	assert.equal(sortClasses(npmDedupe.apply(null, fixture.args)), sortClasses(fixture.expected));
 	assert.equal(sortClasses(bind.apply(null, fixture.args)), sortClasses(fixture.expected));
 	assert.equal(sortClasses(npmBind.apply(null, fixture.args)), sortClasses(fixture.expected));
+	assert.equal(sortClasses(join.apply(null, fixture.args)), sortClasses(fixture.expected));
 }
 
 module.exports = runChecks;

--- a/benchmarks/runChecks.js
+++ b/benchmarks/runChecks.js
@@ -4,12 +4,14 @@ function sortClasses (str) {
 	return str.split(' ').sort().join(' ');
 }
 
-function runChecks (local, npm, dedupe, npmDedupe, fixture) {
+function runChecks (local, npm, dedupe, npmDedupe, bind, npmBind, fixture) {
 	// sort assertions because dedupe returns results in a different order
 	assert.equal(sortClasses(local.apply(null, fixture.args)), sortClasses(fixture.expected));
 	assert.equal(sortClasses(dedupe.apply(null, fixture.args)), sortClasses(fixture.expected));
 	assert.equal(sortClasses(npm.apply(null, fixture.args)), sortClasses(fixture.expected));
 	assert.equal(sortClasses(npmDedupe.apply(null, fixture.args)), sortClasses(fixture.expected));
+	assert.equal(sortClasses(bind.apply(null, fixture.args)), sortClasses(fixture.expected));
+	assert.equal(sortClasses(npmBind.apply(null, fixture.args)), sortClasses(fixture.expected));
 }
 
 module.exports = runChecks;

--- a/benchmarks/runInBrowser.js
+++ b/benchmarks/runInBrowser.js
@@ -1,6 +1,15 @@
 var fixtures = require('./fixtures');
+var cssModule = {
+	'one': 'one',
+	'two': 'two',
+	'three': 'three',
+	'four': 'four',
+	'five': 'five',
+	'six': 'six'
+};
 var local = require('../');
 var dedupe = require('../dedupe');
+var bind = require('../bind').bind(cssModule);
 var localPackage = require('../package.json');
 
 var npm = require('classnames');
@@ -41,7 +50,7 @@ window.onload = function () {
 	log(navigator.userAgent);
 	setTimeout(function () {
 		deferredForEach(fixtures, function (f) {
-			runSuite(local, npm, dedupe, npmDedupe, f, log);
+			runSuite(local, npm, dedupe, npmDedupe, bind, npmBind, f, log);
 		}, function () {
 			log('Finished');
 			document.getElementById('loader').style.display = 'none';

--- a/benchmarks/runInBrowser.js
+++ b/benchmarks/runInBrowser.js
@@ -7,9 +7,20 @@ var cssModule = {
 	'five': 'five',
 	'six': 'six'
 };
+var cssModule1 = {
+	'one': 'one',
+	'two': 'two',
+	'three': 'three'
+}
+var cssModule2 = {
+	'four': 'four',
+	'five': 'five',
+	'six': 'six'
+};
 var local = require('../');
 var dedupe = require('../dedupe');
 var bind = require('../bind').bind(cssModule);
+var join = require('../bind').join(cssModule1, cssModule2);
 var localPackage = require('../package.json');
 
 var npm = require('classnames');
@@ -50,7 +61,7 @@ window.onload = function () {
 	log(navigator.userAgent);
 	setTimeout(function () {
 		deferredForEach(fixtures, function (f) {
-			runSuite(local, npm, dedupe, npmDedupe, bind, npmBind, f, log);
+			runSuite(local, npm, dedupe, npmDedupe, bind, npmBind, join, f, log);
 		}, function () {
 			log('Finished');
 			document.getElementById('loader').style.display = 'none';

--- a/benchmarks/runSuite.js
+++ b/benchmarks/runSuite.js
@@ -1,6 +1,6 @@
 var benchmark = require('benchmark');
 
-function runSuite (local, npm, dedupe, npmDedupe, bind, npmBind, fixture, log) {
+function runSuite (local, npm, dedupe, npmDedupe, bind, npmBind, join, fixture, log) {
 	var suite = new benchmark.Suite();
 
 	suite.add('local#' + fixture.description, function () {
@@ -25,6 +25,10 @@ function runSuite (local, npm, dedupe, npmDedupe, bind, npmBind, fixture, log) {
 
 	suite.add('  npm/bind#' + fixture.description, function () {
 		npmBind.apply(null, fixture.args);
+	});
+
+	suite.add('local/join#' + fixture.description, function () {
+		join.apply(null, fixture.args);
 	});
 
 	// after each cycle

--- a/benchmarks/runSuite.js
+++ b/benchmarks/runSuite.js
@@ -1,6 +1,6 @@
 var benchmark = require('benchmark');
 
-function runSuite (local, npm, dedupe, npmDedupe, fixture, log) {
+function runSuite (local, npm, dedupe, npmDedupe, bind, npmBind, fixture, log) {
 	var suite = new benchmark.Suite();
 
 	suite.add('local#' + fixture.description, function () {
@@ -17,6 +17,14 @@ function runSuite (local, npm, dedupe, npmDedupe, fixture, log) {
 
 	suite.add('  npm/dedupe#' + fixture.description, function () {
 		npmDedupe.apply(null, fixture.args);
+	});
+
+	suite.add('local/bind#' + fixture.description, function () {
+		bind.apply(null, fixture.args);
+	});
+
+	suite.add('  npm/bind#' + fixture.description, function () {
+		npmBind.apply(null, fixture.args);
 	});
 
 	// after each cycle

--- a/bind.js
+++ b/bind.js
@@ -10,6 +10,15 @@
 
 	var hasOwn = {}.hasOwnProperty;
 
+	function join () {
+		var context = {}
+		for (var i = 0; i < arguments.length; i++) {
+			var arg = arguments[i]
+			Object.assign(context, arg)
+		}
+		return classNames.bind(context)
+	}
+
 	function classNames () {
 		var classes = [];
 
@@ -34,6 +43,8 @@
 
 		return classes.join(' ');
 	}
+
+	classNames.join = join
 
 	if (typeof module !== 'undefined' && module.exports) {
 		module.exports = classNames;

--- a/tests/bind.js
+++ b/tests/bind.js
@@ -12,7 +12,20 @@ var cssModulesMock = {
 	f: "#f"
 };
 
+var cssModulesMock1 = {
+	a: "#a",
+	b: "#b",
+	c: "#c"
+}
+
+var cssModulesMock2 = {
+	d: "#d",
+	e: "#e",
+	f: "#f"
+};
+
 var classNamesBound = classNames.bind(cssModulesMock);
+var classNamesJoined = classNames.join(cssModulesMock1, cssModulesMock2);
 
 describe('bind', function () {
 	describe('classNames', function () {
@@ -143,4 +156,73 @@ describe('bind', function () {
 		});
 	});
 
+	describe('classNamesJoined', function () {
+		it('keeps object keys with truthy values', function () {
+			assert.equal(classNamesJoined({
+				a: true,
+				b: false,
+				c: 0,
+				d: null,
+				e: undefined,
+				f: 1
+			}), '#a #f');
+		});
+		it('keeps class names undefined in bound hash', function () {
+			assert.equal(classNamesJoined({
+				a: true,
+				b: false,
+				c: 0,
+				d: null,
+				e: undefined,
+				f: 1,
+				x: true,
+				y: null,
+				z: 1
+			}), '#a #f x z');
+		})
+		it('joins arrays of class names and ignore falsy values', function () {
+			assert.equal(classNamesJoined('a', 0, null, undefined, true, 1, 'b'), '#a 1 #b');
+		});
+
+		it('supports heterogenous arguments', function () {
+			assert.equal(classNamesJoined({a: true}, 'b', 0), '#a #b');
+		});
+
+		it('should be trimmed', function () {
+			assert.equal(classNamesJoined('', 'b', {}, ''), '#b');
+		});
+
+		it('returns an empty string for an empty configuration', function () {
+			assert.equal(classNamesJoined({}), '');
+		});
+
+		it('supports an array of class names', function () {
+			assert.equal(classNamesJoined(['a', 'b']), '#a #b');
+		});
+
+		it('joins array arguments with string arguments', function () {
+			assert.equal(classNamesJoined(['a', 'b'], 'c'), '#a #b #c');
+			assert.equal(classNamesJoined('c', ['a', 'b']), '#c #a #b');
+		});
+
+		it('handles multiple array arguments', function () {
+			assert.equal(classNamesJoined(['a', 'b'], ['c', 'd']), '#a #b #c #d');
+		});
+
+		it('handles arrays that include falsy and true values', function () {
+			assert.equal(classNamesJoined(['a', 0, null, undefined, false, true, 'b']), '#a #b');
+		});
+
+		it('handles arrays that include arrays', function () {
+			assert.equal(classNamesJoined(['a', ['b', 'c']]), '#a #b #c');
+		});
+
+		it('handles arrays that include objects', function () {
+			assert.equal(classNamesJoined(['a', {b: true, c: false}]), '#a #b');
+		});
+
+		it('handles deep array recursion', function () {
+			assert.equal(classNamesJoined(['a', ['b', ['c', {d: true}]]]), '#a #b #c #d');
+		});
+	});
 })


### PR DESCRIPTION
A few notes --

I've added both `bind` and `join` to the benchmarks, seems bind was missing.  

I wasn't sure what to do for benchmarks for the npm variant `join` as it doesn't exist in npm now.  I left it out.  Still, gives a comparison with `bind`.

I've added the method as a property on the export of the `bind` file so one will be able to use `classNames.join` instead of bind if desired.  

This uses `Object.assign` so I added a note about using a polyfill for older browsers... also made an assumption about the starting version for that as the next minor bump.

Resolves #130 