### PR TITLE
Fix issue with empty arrays being pushed

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,11 +22,10 @@
 			if (argType === 'string' || argType === 'number') {
 				classes.push(arg);
 			} else if (Array.isArray(arg) && arg.length) {
-				// if the element inside the array is an empty array do not push it
-				if (Array.isArray(arg[0]) && !arg[0].length) {
-					continue
+				var inner = classNames.apply(null, arg);
+				if (inner) {
+					classes.push(inner);
 				}
-				classes.push(classNames.apply(null, arg));
 			} else if (argType === 'object') {
 				for (var key in arg) {
 					if (hasOwn.call(arg, key) && arg[key]) {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,11 @@
 
 			if (argType === 'string' || argType === 'number') {
 				classes.push(arg);
-			} else if (Array.isArray(arg)) {
+			} else if (Array.isArray(arg) && arg.length) {
+				// if the element inside the array is an empty array do not push it
+				if (Array.isArray(arg[0]) && !arg[0].length) {
+					continue
+				}
 				classes.push(classNames.apply(null, arg));
 			} else if (argType === 'object') {
 				for (var key in arg) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -59,4 +59,12 @@ describe('classNames', function () {
 	it('handles deep array recursion', function () {
 		assert.equal(classNames(['a', ['b', ['c', {d: true}]]]), 'a b c d');
 	});
+
+	it('handles arrays that are empty', function () {
+		assert.equal(classNames('a', []), 'a');
+	});
+
+	it('handles nested arrays that have empty nested arrays', function () {
+		assert.equal(classNames('a', [[]]), 'a');
+	});
 });


### PR DESCRIPTION
Arrays that are a 2nd parameter to  classNames, and arrays that contain empty nested arrays get pushed resulting in spaces at the end of the classNames function output. This PR fixes that issue.