### PR TITLE
Update Readme for npm ^5 --save

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple JavaScript utility for conditionally joining classNames together.
 
 Install with [npm](https://www.npmjs.com/), [Bower](https://bower.io/), or [Yarn](https://yarnpkg.com/):
 
-npm:
+npm (note you don't need `--save` as npm ^5 it automatically saves the package to the `dependencies` in `package.json`):
 ```sh
 npm install classnames --save
 ```


### PR DESCRIPTION
From npm version 5, there is no need for `--save` flag because it automatically saves package into dependency section in package.json.