### PR TITLE
Return null when classes is an empty array

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@
 			}
 		}
 
-		return classes.join(' ');
+		return classes.length ? classes.join(' ') : null;
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
If the ```classes``` is an empty array, the method ```join(' ')``` will return empty string.
But the empty string of react's ```className``` would cause react generate class attribute without value.
So I think it's better to return null when the ```classes``` is an empty array.