### PR TITLE
Make the AMD module check less restrictive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
-before_install:
-  - "npm install npm -g"
+
 node_js:
   - "stable"
   - "4"

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@
 	if (typeof module !== 'undefined' && module.exports) {
 		classNames.default = classNames;
 		module.exports = classNames;
-	} else if (typeof define === 'function' && typeof define.amd === 'object' && define.amd) {
+	} else if (typeof define === 'function' && define.amd) {
 		// register as 'classnames', consistent with npm package name
 		define('classnames', [], function () {
 			return classNames;


### PR DESCRIPTION
If you look at how UMD recommends defining an AMD module, it doesn't
include a check that `define.amd` is an `object`.

https://github.com/umdjs/umd/blob/36fd1135ba44e758c7371e7af72295acdebce010/templates/amdWeb.js#L19

That check was breaking import from the `ember-cli` which supports AMD
modules but does not include `define.amd` as an `object`.