### PR TITLE
add __esModule: true when exports

### DIFF
--- a/bind.js
+++ b/bind.js
@@ -38,6 +38,7 @@
 	if (typeof module !== 'undefined' && module.exports) {
 		classNames.default = classNames;
 		module.exports = classNames;
+		module.exports.__esModule = true;
 	} else if (typeof define === 'function' && typeof define.amd === 'object' && define.amd) {
 		// register as 'classnames', consistent with npm package name
 		define('classnames', [], function () {

--- a/dedupe.js
+++ b/dedupe.js
@@ -99,6 +99,7 @@
 	if (typeof module !== 'undefined' && module.exports) {
 		classNames.default = classNames;
 		module.exports = classNames;
+		module.exports.__esModule = true;
 	} else if (typeof define === 'function' && typeof define.amd === 'object' && define.amd) {
 		// register as 'classnames', consistent with npm package name
 		define('classnames', [], function () {

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@
 	if (typeof module !== 'undefined' && module.exports) {
 		classNames.default = classNames;
 		module.exports = classNames;
+		module.exports.__esModule = true;
 	} else if (typeof define === 'function' && typeof define.amd === 'object' && define.amd) {
 		// register as 'classnames', consistent with npm package name
 		define('classnames', [], function () {


### PR DESCRIPTION
since babel _interopRequireWildcard doesn't do the right copy to the new newObj
when the module.exports is a function

and classnames is actually a function exports

see https://github.com/babel/babel/issues/3956
and https://github.com/babel/babel/blob/master/packages/babel-helpers/src/helpers.js#L544