### PR TITLE
exported concealed types in TypeScript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
-declare type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | false;
+export type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | false;
 
-interface ClassDictionary {
+export interface ClassDictionary {
 	[id: string]: boolean | undefined | null;
 }
 
-interface ClassArray extends Array<ClassValue> { }
+export interface ClassArray extends Array<ClassValue> { }
 
 interface ClassNamesFn {
 	(...classes: ClassValue[]): string;


### PR DESCRIPTION
Just exporting the additional types that the classnames function takes as arguments. Especially useful when you want to create a reusable component that accepts a `ClassValue` as a prop.