### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Install with [npm](https://www.npmjs.com/), [Bower](https://bower.io/), or [Yarn
 
 npm:
 ```sh
-npm install classnames --save
+npm install classnames
 ```
 
 Bower:
 ```sh
-bower install classnames --save
+bower install classnames
 ```
 
 Yarn (note that `yarn add` automatically saves the package to the `dependencies` in `package.json`):


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358