### PR TITLE
Add missing quotes in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ class Button extends React.Component {
   // ...
   render () {
     var btnClass = classNames({
-      btn: true,
+      'btn': true,
       'btn-pressed': this.state.isPressed,
       'btn-over': !this.state.isPressed && this.state.isHovered
     });


### PR DESCRIPTION
## Add missing quotes in README.md example

This `btn` should be a string:

![image](https://user-images.githubusercontent.com/17011229/56077710-089fd880-5de8-11e9-9fdd-867d069d0da4.png)
