### PR TITLE
Vast performance improvements;

### DIFF
--- a/bind.js
+++ b/bind.js
@@ -1,8 +1,8 @@
 /*!
-  Copyright (c) 2018 Jed Watson.
-  Licensed under the MIT License (MIT), see
-  http://jedwatson.github.io/classnames
-*/
+ Copyright (c) 2018 Jed Watson.
+ Licensed under the MIT License (MIT), see
+ http://jedwatson.github.io/classnames
+ */
 /* global define */
 
 (function () {
@@ -11,49 +11,60 @@
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 	var isArray = Array.isArray;
 
-	function reduceArray (arr, that) {
-		var len = arr.length;
-		if (!len)
+	function classNames()
+	{
+		var len = arguments.length;
+
+		if (!len){
 			return "";
+		}
+
 		var str = "", item, i, n;
 		for (i = 0; i < len; i++) {
-			if (!(item = arr[i]))
-				continue;
-			if (typeof item === "string" || typeof item === "number") {
-				(item = that && that[item] || item), str && (str += " "), (str += item);
+			if (!(item = arguments[i])) {
 				continue;
 			}
+
+			if (typeof item === "string" || typeof item === "number") {
+				str && (str += " ");
+				(str += this && this[item] || item);
+				continue;
+			}
+
 			if (typeof item !== "object")
 				continue;
+
 			if (isArray(item)) {
-				if (item.length && (item = reduceArray(item, that))) {
-					str && (str += " "), (str += item);
+				if ((item = classNames.apply(this, item))){
+					str && (str += " ");
+					(str += item);
 				}
+
+				continue;
 			}
-			else {
-				for (n in item) {
-					if (hasOwnProperty.call(item, n) && item[n] && n) {
-						(n = that && that[n] || n), (str && (str += " ")), (str += n);
-					}
+
+			for (n in item) {
+				if (hasOwnProperty.call(item, n) && item[n] && n){
+					str && (str += " ");
+					(str += this && this[n] || n);
 				}
 			}
 		}
-		return str;
-	}
 
-	function classNames() {
-		return reduceArray(arguments, this);
+		return str;
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {
 		classNames.default = classNames;
 		module.exports = classNames;
-	} else if (typeof define === 'function' && typeof define.amd === 'object' && define.amd) {
+	}
+	else if (typeof define === 'function' && typeof define.amd === 'object' && define.amd) {
 		// register as 'classnames', consistent with npm package name
 		define('classnames', [], function () {
 			return classNames;
 		});
-	} else {
+	}
+	else {
 		window.classNames = classNames;
 	}
 }());

--- a/bind.js
+++ b/bind.js
@@ -11,29 +11,29 @@
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 	var isArray = Array.isArray;
 
-	function reduceArray (args, context) {
-		var len = args.length;
+	function reduceArray (arr, that) {
+		var len = arr.length;
 		if (!len)
 			return "";
 		var str = "", item, i, n;
 		for (i = 0; i < len; i++) {
-			if (!(item = args[i]))
+			if (!(item = arr[i]))
 				continue;
 			if (typeof item === "string" || typeof item === "number") {
-				(item = context && context[item] || item), str && (str += " "), (str += item);
+				(item = that && that[item] || item), str && (str += " "), (str += item);
 				continue;
 			}
 			if (typeof item !== "object")
 				continue;
 			if (isArray(item)) {
-				if (item.length && (item = reduceArray(item, context))) {
+				if (item.length && (item = reduceArray(item, that))) {
 					str && (str += " "), (str += item);
 				}
 			}
 			else {
 				for (n in item) {
 					if (hasOwnProperty.call(item, n) && item[n] && n) {
-						(n = context && context[n] || n), (str && (str += " ")), (str += n);
+						(n = that && that[n] || n), (str && (str += " ")), (str += n);
 					}
 				}
 			}

--- a/bind.js
+++ b/bind.js
@@ -15,29 +15,23 @@
 	{
 		var len = arguments.length;
 
-		if (!len){
-			return "";
-		}
+		if (!len) return '';
 
-		var str = "", item, i, n;
+		var str = '', item, i, n;
 		for (i = 0; i < len; i++) {
-			if (!(item = arguments[i])) {
-				continue;
-			}
+			if (!(item = arguments[i])) continue;
 
-			if (typeof item === "string" || typeof item === "number") {
-				str && (str += " ");
+			if (typeof item === 'string' || typeof item === 'number') {
+				str && (str += ' ');
 				(str += this && this[item] || item);
 				continue;
 			}
 
-			if (typeof item !== "object") {
-				continue;
-			}
+			if (typeof item !== 'object') continue;
 
 			if (isArray(item)) {
-				if ((item = classNames.apply(this, item))){
-					str && (str += " ");
+				if ((item = classNames.apply(this, item))) {
+					str && (str += ' ');
 					(str += item);
 				}
 
@@ -45,8 +39,8 @@
 			}
 
 			for (n in item) {
-				if (hasOwnProperty.call(item, n) && item[n] && n){
-					str && (str += " ");
+				if (hasOwnProperty.call(item, n) && item[n] && n) {
+					str && (str += ' ');
 					(str += this && this[n] || n);
 				}
 			}

--- a/bind.js
+++ b/bind.js
@@ -31,8 +31,9 @@
 				continue;
 			}
 
-			if (typeof item !== "object")
+			if (typeof item !== "object") {
 				continue;
+			}
 
 			if (isArray(item)) {
 				if ((item = classNames.apply(this, item))){

--- a/bind.js
+++ b/bind.js
@@ -8,31 +8,41 @@
 (function () {
 	'use strict';
 
-	var hasOwn = {}.hasOwnProperty;
+	var hasOwnProperty = Object.prototype.hasOwnProperty;
+	var isArray = Array.isArray;
 
-	function classNames () {
-		var classes = [];
-
-		for (var i = 0; i < arguments.length; i++) {
-			var arg = arguments[i];
-			if (!arg) continue;
-
-			var argType = typeof arg;
-
-			if (argType === 'string' || argType === 'number') {
-				classes.push(this && this[arg] || arg);
-			} else if (Array.isArray(arg)) {
-				classes.push(classNames.apply(this, arg));
-			} else if (argType === 'object') {
-				for (var key in arg) {
-					if (hasOwn.call(arg, key) && arg[key]) {
-						classes.push(this && this[key] || key);
+	function reduceArray (args, context) {
+		var len = args.length;
+		if (!len)
+			return "";
+		var str = "", item, i, n;
+		for (i = 0; i < len; i++) {
+			if (!(item = args[i]))
+				continue;
+			if (typeof item === "string" || typeof item === "number") {
+				(item = context && context[item] || item), str && (str += " "), (str += item);
+				continue;
+			}
+			if (typeof item !== "object")
+				continue;
+			if (isArray(item)) {
+				if (item.length && (item = reduceArray(item, context))) {
+					str && (str += " "), (str += item);
+				}
+			}
+			else {
+				for (n in item) {
+					if (hasOwnProperty.call(item, n) && item[n] && n) {
+						(n = context && context[n] || n), (str && (str += " ")), (str += n);
 					}
 				}
 			}
 		}
+		return str;
+	}
 
-		return classes.join(' ');
+	function classNames() {
+		return reduceArray(arguments, this);
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {

--- a/dedupe.js
+++ b/dedupe.js
@@ -51,7 +51,7 @@
 	function classNames(){
 		var classSet = new StorageObject();
 
-		var str = "", n,
+		var str = '', n,
 			len = arguments.length;
 
 		for (n = 0; n < len; n++) {
@@ -60,7 +60,7 @@
 
 		for (n in classSet) {
 			if (classSet[n]) {
-				str && (str += " "), (str += n);
+				str && (str += ' '), (str += n);
 			}
 		}
 

--- a/dedupe.js
+++ b/dedupe.js
@@ -1,100 +1,71 @@
 /*!
-  Copyright (c) 2018 Jed Watson.
-  Licensed under the MIT License (MIT), see
-  http://jedwatson.github.io/classnames
-*/
+ Copyright (c) 2018 Jed Watson.
+ Licensed under the MIT License (MIT), see
+ http://jedwatson.github.io/classnames
+ */
 /* global define */
 
 (function () {
 	'use strict';
 
-	var classNames = (function () {
-		// don't inherit from Object so we can skip hasOwnProperty check later
-		// http://stackoverflow.com/questions/15518328/creating-js-object-with-object-createnull#answer-21079232
-		function StorageObject() {}
-		StorageObject.prototype = Object.create(null);
+	var hasOwn = Object.prototype.hasOwnProperty;
+	var isArray = Array.isArray;
+	var SPACE = /\s+/;
+	
+	// don't inherit from Object so we can skip hasOwnProperty check later
+	// http://stackoverflow.com/questions/15518328/creating-js-object-with-object-createnull#answer-21079232
+	function StorageObject() {}
+	StorageObject.prototype = Object.create(null);
 
-		function _parseArray (resultSet, array) {
-			var length = array.length;
+	function _parse (resultSet, arg) {
+		if (!arg) return;
+		
+		var i, length;
+		
+		if (typeof arg === 'string') { // 'foo bar'
+			var array = arg.split(SPACE);
+			length = array.length;
 
-			for (var i = 0; i < length; ++i) {
-				_parse(resultSet, array[i]);
-			}
-		}
-
-		var hasOwn = {}.hasOwnProperty;
-
-		function _parseNumber (resultSet, num) {
-			resultSet[num] = true;
-		}
-
-		function _parseObject (resultSet, object) {
-			for (var k in object) {
-				if (hasOwn.call(object, k)) {
-					// set value to false instead of deleting it to avoid changing object structure
-					// https://www.smashingmagazine.com/2012/11/writing-fast-memory-efficient-javascript/#de-referencing-misconceptions
-					resultSet[k] = !!object[k];
-				}
-			}
-		}
-
-		var SPACE = /\s+/;
-		function _parseString (resultSet, str) {
-			var array = str.split(SPACE);
-			var length = array.length;
-
-			for (var i = 0; i < length; ++i) {
+			for (i = 0; i < length; ++i) {
 				resultSet[array[i]] = true;
 			}
-		}
+		} else if (isArray(arg)) { // ['foo', 'bar', ...]
+			length = arg.length;
 
-		function _parse (resultSet, arg) {
-			if (!arg) return;
-			var argType = typeof arg;
-
-			// 'foo bar'
-			if (argType === 'string') {
-				_parseString(resultSet, arg);
-
-			// ['foo', 'bar', ...]
-			} else if (Array.isArray(arg)) {
-				_parseArray(resultSet, arg);
-
-			// { 'foo': true, ... }
-			} else if (argType === 'object') {
-				_parseObject(resultSet, arg);
-
-			// '130'
-			} else if (argType === 'number') {
-				_parseNumber(resultSet, arg);
+			for (i = 0; i < length; ++i) {
+				_parse(resultSet, arg[i]);
 			}
-		}
-
-		function _classNames () {
-			// don't leak arguments
-			// https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
-			var len = arguments.length;
-			var args = Array(len);
-			for (var i = 0; i < len; i++) {
-				args[i] = arguments[i];
-			}
-
-			var classSet = new StorageObject();
-			_parseArray(classSet, args);
-
-			var list = [];
-
-			for (var k in classSet) {
-				if (classSet[k]) {
-					list.push(k)
+		} else if (typeof arg === 'object') { // { 'foo': true, ... }
+			for (i in arg) {
+				if (hasOwn.call(arg, i)) {
+					// set value to false instead of deleting it to avoid changing object structure
+					// https://www.smashingmagazine.com/2012/11/writing-fast-memory-efficient-javascript/#de-referencing-misconceptions
+					resultSet[i] = !!arg[i];
 				}
 			}
+		} else if (typeof arg === 'number') { // '130'
+			resultSet[arg] = true;
+		}
+	}
+	
+	function classNames(){
+		var classSet = new StorageObject();
 
-			return list.join(' ');
+		var str = "", n,
+			len = arguments.length;
+
+		for (n = 0; n < len; n++) {
+			_parse(classSet, arguments[n]);
 		}
 
-		return _classNames;
-	})();
+		for (n in classSet) {
+			if (classSet[n]) {
+				str && (str += " "), (str += n);
+			}
+		}
+
+		return str;
+	}
 
 	if (typeof module !== 'undefined' && module.exports) {
 		classNames.default = classNames;

--- a/index.js
+++ b/index.js
@@ -8,35 +8,44 @@
 (function () {
 	'use strict';
 
-	var hasOwn = {}.hasOwnProperty;
+	var hasOwnProperty = Object.prototype.hasOwnProperty;
+	var isArray = Array.isArray;
 
-	function classNames () {
-		var classes = [];
-
-		for (var i = 0; i < arguments.length; i++) {
-			var arg = arguments[i];
-			if (!arg) continue;
-
-			var argType = typeof arg;
-
-			if (argType === 'string' || argType === 'number') {
-				classes.push(arg);
-			} else if (Array.isArray(arg) && arg.length) {
-				var inner = classNames.apply(null, arg);
-				if (inner) {
-					classes.push(inner);
+	function reduceArray (args) {
+		var len = args.length;
+		if (!len)
+			return "";
+		var str = "", item, type, i, n;
+		for (i = 0; i < len; i++) {
+			if (!(item = args[i]))
+				continue;
+			type = typeof item;
+			if (type === "string" || type === "number") {
+				str && (str += " "), (str += item);
+				continue;
+			}
+			if (type !== "object")
+				continue;
+			if (isArray(item)) {
+				if (item.length && (item = reduceArray(item))) {
+					str && (str += " "), (str += item);
 				}
-			} else if (argType === 'object') {
-				for (var key in arg) {
-					if (hasOwn.call(arg, key) && arg[key]) {
-						classes.push(key);
+			}
+			else {
+				for (n in item) {
+					if (hasOwnProperty.call(item, n) && item[n] && n) {
+						str && (str += " "), (str += n);
 					}
 				}
 			}
 		}
-
-		return classes.join(' ');
+		return str;
 	}
+	
+	function classNames() {
+		return reduceArray(arguments);
+	}
+	
 
 	if (typeof module !== 'undefined' && module.exports) {
 		classNames.default = classNames;

--- a/index.js
+++ b/index.js
@@ -30,8 +30,9 @@
 				continue;
 			}
 
-			if (typeof item !== "object")
+			if (typeof item !== "object") {
 				continue;
+			}
 
 			if (isArray(item)) {
 				if ((item = classNames.apply(this, item))){

--- a/index.js
+++ b/index.js
@@ -10,39 +10,47 @@
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 	var isArray = Array.isArray;
+	
+	function classNames() {
+		var len = arguments.length;
 
-	function reduceArray (arr) {
-		var len = arr.length;
-		if (!len)
+		if (!len){
 			return "";
+		}
+
 		var str = "", item, i, n;
 		for (i = 0; i < len; i++) {
-			if (!(item = arr[i]))
-				continue;
-			if (typeof item === "string" || typeof item === "number") {
-				str && (str += " "), (str += item);
+			if (!(item = arguments[i])) {
 				continue;
 			}
+
+			if (typeof item === "string" || typeof item === "number") {
+				str && (str += " ");
+				(str += item);
+				continue;
+			}
+
 			if (typeof item !== "object")
 				continue;
+
 			if (isArray(item)) {
-				if (item.length && (item = reduceArray(item))) {
-					str && (str += " "), (str += item);
+				if ((item = classNames.apply(this, item))){
+					str && (str += " ");
+					(str += item);
 				}
+
+				continue;
 			}
-			else {
-				for (n in item) {
-					if (hasOwnProperty.call(item, n) && item[n] && n) {
-						str && (str += " "), (str += n);
-					}
+
+			for (n in item) {
+				if (hasOwnProperty.call(item, n) && item[n] && n){
+					str && (str += " ");
+					(str += n);
 				}
 			}
 		}
+		
 		return str;
-	}
-	
-	function classNames() {
-		return reduceArray(arguments);
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {

--- a/index.js
+++ b/index.js
@@ -14,29 +14,23 @@
 	function classNames() {
 		var len = arguments.length;
 
-		if (!len){
-			return "";
-		}
+		if (!len) return '';
 
-		var str = "", item, i, n;
+		var str = '', item, i, n;
 		for (i = 0; i < len; i++) {
-			if (!(item = arguments[i])) {
-				continue;
-			}
+			if (!(item = arguments[i]))	continue;
 
-			if (typeof item === "string" || typeof item === "number") {
-				str && (str += " ");
+			if (typeof item === 'string' || typeof item === 'number') {
+				str && (str += ' ');
 				(str += item);
 				continue;
 			}
 
-			if (typeof item !== "object") {
-				continue;
-			}
+			if (typeof item !== 'object') continue;
 
 			if (isArray(item)) {
 				if ((item = classNames.apply(this, item))){
-					str && (str += " ");
+					str && (str += ' ');
 					(str += item);
 				}
 
@@ -45,7 +39,7 @@
 
 			for (n in item) {
 				if (hasOwnProperty.call(item, n) && item[n] && n){
-					str && (str += " ");
+					str && (str += ' ');
 					(str += n);
 				}
 			}

--- a/index.js
+++ b/index.js
@@ -15,16 +15,15 @@
 		var len = args.length;
 		if (!len)
 			return "";
-		var str = "", item, type, i, n;
+		var str = "", item, i, n;
 		for (i = 0; i < len; i++) {
 			if (!(item = args[i]))
 				continue;
-			type = typeof item;
-			if (type === "string" || type === "number") {
+			if (typeof item === "string" || typeof item === "number") {
 				str && (str += " "), (str += item);
 				continue;
 			}
-			if (type !== "object")
+			if (typeof item !== "object")
 				continue;
 			if (isArray(item)) {
 				if (item.length && (item = reduceArray(item))) {
@@ -45,7 +44,6 @@
 	function classNames() {
 		return reduceArray(arguments);
 	}
-	
 
 	if (typeof module !== 'undefined' && module.exports) {
 		classNames.default = classNames;

--- a/index.js
+++ b/index.js
@@ -11,13 +11,13 @@
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 	var isArray = Array.isArray;
 
-	function reduceArray (args) {
-		var len = args.length;
+	function reduceArray (arr) {
+		var len = arr.length;
 		if (!len)
 			return "";
 		var str = "", item, i, n;
 		for (i = 0; i < len; i++) {
-			if (!(item = args[i]))
+			if (!(item = arr[i]))
 				continue;
 			if (typeof item === "string" || typeof item === "number") {
 				str && (str += " "), (str += item);


### PR DESCRIPTION
Reworked all implementations (regular, dedupe, bind).
No breaking changes.

Benchmarks:
```bash
> node ./benchmarks/run

* local#strings x 15,466,941 ops/sec ±0.36% (92 runs sampled)
*   npm#strings x 3,646,035 ops/sec ±1.69% (88 runs sampled)
* local/dedupe#strings x 2,648,941 ops/sec ±0.19% (93 runs sampled)
*   npm/dedupe#strings x 1,470,214 ops/sec ±1.71% (94 runs sampled)

> Fastest is local#strings

* local#object x 17,545,632 ops/sec ±0.42% (93 runs sampled)
*   npm#object x 3,899,880 ops/sec ±1.32% (93 runs sampled)
* local/dedupe#object x 7,118,462 ops/sec ±0.26% (91 runs sampled)
*   npm/dedupe#object x 2,632,530 ops/sec ±0.16% (94 runs sampled)

> Fastest is local#object

* local#strings, object x 11,379,569 ops/sec ±0.44% (95 runs sampled)
*   npm#strings, object x 3,259,972 ops/sec ±0.40% (94 runs sampled)
* local/dedupe#strings, object x 2,525,953 ops/sec ±1.49% (93 runs sampled)
*   npm/dedupe#strings, object x 1,548,802 ops/sec ±0.14% (92 runs sampled)

> Fastest is local#strings, object

* local#mix x 7,226,283 ops/sec ±0.20% (95 runs sampled)
*   npm#mix x 2,521,931 ops/sec ±1.39% (93 runs sampled)
* local/dedupe#mix x 907,851 ops/sec ±0.39% (93 runs sampled)
*   npm/dedupe#mix x 667,852 ops/sec ±0.84% (95 runs sampled)

> Fastest is local#mix

* local#arrays x 3,571,391 ops/sec ±0.17% (94 runs sampled)
*   npm#arrays x 919,980 ops/sec ±0.22% (91 runs sampled)
* local/dedupe#arrays x 1,028,421 ops/sec ±1.41% (95 runs sampled)
*   npm/dedupe#arrays x 743,585 ops/sec ±0.17% (94 runs sampled)

> Fastest is local#arrays
```