### PR TITLE
Remove named exports from type definitions

### DIFF
--- a/bind.d.ts
+++ b/bind.d.ts
@@ -5,6 +5,6 @@ export interface IClassNamesBind
 	bind: (styles: any) => typeof base
 }
 
-export const classNames: IClassNamesBind;
+declare const classNames: IClassNamesBind;
 
 export default classNames;

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,4 @@ export type Value = string | number | boolean | undefined | null;
 export type Mapping = { [key: string]: Value };
 export type Argument = Value | Mapping | Argument[];
 
-export function classNames(...args: Argument[]): string;
-
-export default classNames;
+export default function classNames(...args: Argument[]): string;


### PR DESCRIPTION
These exports don’t exist in the implementation.