### PR TITLE
Fix value types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@
 //   Marvin Hagemeister <https://github.com/marvinhagemeister>
 
 export type Value = string | number | boolean | undefined | null;
-export type Mapping = { [key: string]: Value };
+export type Mapping = { [key: string]: any };
 export type Argument = Value | Mapping | Argument[];
 
 export function classNames(...args: Argument[]): string;


### PR DESCRIPTION
A mapping consistes of classnames mapped to a value checked its booliness to
determine if the classnames should be added. These values may be anything,
they’re not related to the allowed class values.