### PR TITLE
Bugfix - Class names being returned as [object Object]

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@
 					}
 				}
 			} else if (argType === 'object') {
-				if (arg.toString === Object.prototype.toString) {
+				if (!arg.hasOwnProperty('toString')) {
 					for (var key in arg) {
 						if (hasOwn.call(arg, key) && arg[key]) {
 							classes.push(key);


### PR DESCRIPTION
Updated to use `hasOwnProperty` over trying to compare the Object prototype which fails with some build pipelines after transpilation. See issue #240.