### PR TITLE
Add GitHub Actions and run tests for all supported Node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - run: npm ci
+    - run: npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - "stable"
-  - "10"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Classnames
 ===========
 
 [![NPM version](https://badgen.net/npm/v/classnames)](https://www.npmjs.com/package/classnames)
-[![Build status](https://badgen.net/travis/JedWatson/classnames)](https://travis-ci.org/JedWatson/classnames)
 [![NPM Weekly Downloads](https://badgen.net/npm/dw/classnames)](https://www.npmjs.com/package/classnames)
 [![License](https://badgen.net/npm/license/classnames)](https://www.npmjs.com/package/classnames)
 [![Supported by Thinkmill](https://thinkmill.github.io/badge/heart.svg)](https://thinkmill.com.au/?utm_source=github&utm_medium=badge&utm_campaign=classnames)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "url": "https://github.com/JedWatson/classnames.git"
   },
   "types": "./index.d.ts",
+  "engines": {
+    "node": "^10 || ^12 || ^14 || ^15"
+  },
   "scripts": {
     "benchmarks": "node ./benchmarks/run",
     "benchmarks-browserify": "./node_modules/.bin/browserify ./benchmarks/runInBrowser.js >./benchmarks/runInBrowser.bundle.js",


### PR DESCRIPTION
Replaces Travis with GitHub Actions and runs the tests for all actively [supported versions](https://nodejs.org/en/about/releases/) of Node.