### PR TITLE
Fix bug where objects are converted to '[Object object]' in a VM

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@
 	'use strict';
 
 	var hasOwn = {}.hasOwnProperty;
+	var nativeCodeString = '[native code]';
 
 	function classNames() {
 		var classes = [];
@@ -29,7 +30,7 @@
 					}
 				}
 			} else if (argType === 'object') {
-				if (arg.toString === Object.prototype.toString) {
+				if (arg.toString.toString().indexOf(nativeCodeString) !== -1) {
 					for (var key in arg) {
 						if (hasOwn.call(arg, key) && arg[key]) {
 							classes.push(key);

--- a/tests/index.js
+++ b/tests/index.js
@@ -111,6 +111,7 @@ describe('classNames', function () {
 		var context = { classNames, output: undefined };
 		vm.createContext(context);
 
+		var code = 'output = classNames({ a: true, b: true });';
 
 		vm.runInContext(code, context);
 		assert.equal(context.output, 'a b');

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 
 var assert = require('assert');
+var vm = require('vm');
 var classNames = require('../');
 
 describe('classNames', function () {
@@ -104,5 +105,14 @@ describe('classNames', function () {
 		Class2.prototype = Object.create(Class1.prototype);
 
 		assert.equal(classNames(new Class2()), 'classFromMethod');
+	});
+
+	it('handles objects in a VM', function () {
+		var context = { classNames, output: undefined };
+		vm.createContext(context);
+
+
+		vm.runInContext(code, context);
+		assert.equal(context.output, 'a b');
 	});
 });


### PR DESCRIPTION
Fixes #240

I added a test case that fails against the original implementation.

This comes with a bit of a perf hit but unfortunately there's no way around it if you want to reliably detect the native `toString` function. I made a JSBench so you can see the difference: https://jsbench.me/1xkpq8eozj