### PR TITLE
Fix TypeScript types

### DIFF
--- a/bind.d.ts
+++ b/bind.d.ts
@@ -1,5 +1,9 @@
-export * from '.';
-import { ArgumentArray } from '.';
+import { ArgumentArray } from './index.js';
 
-export type Binding = Record<string, string>;
-export default function classNames(this: Binding | undefined, ...args: ArgumentArray): string;
+declare namespace classNames {
+	type Binding = Record<string, string>;
+}
+
+declare function classNames(this: classNames.Binding | undefined, ...args: ArgumentArray): string;
+
+export = classNames;

--- a/dedupe.d.ts
+++ b/dedupe.d.ts
@@ -1,2 +1,2 @@
-export * from '.';
-export { default } from '.';
+import classNames = require('./index.js');
+export = classNames;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,14 +7,17 @@
 //   Sean Kelley <https://github.com/seansfkelley>
 //   Michal Adamczyk <https://github.com/mradamczyk>
 //   Marvin Hagemeister <https://github.com/marvinhagemeister>
-// TypeScript Version: 3.0
 
-export type Value = string | number | boolean | undefined | null;
-export type Mapping = Record<string, unknown>;
-export interface ArgumentArray extends Array<Argument> {}
-export type Argument = Value | Mapping | ArgumentArray;
+declare namespace classNames {
+  type Value = string | number | boolean | undefined | null;
+  type Mapping = Record<string, unknown>;
+  interface ArgumentArray extends Array<Argument> {}
+  type Argument = Value | Mapping | ArgumentArray;
+}
 
 /**
  * A simple JavaScript utility for conditionally joining classNames together.
  */
-export default function classNames(...args: ArgumentArray): string;
+declare function classNames(...args: classNames.ArgumentArray): string;
+
+export = classNames;

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,6 +1,6 @@
-import classNames from 'classnames';
-import dedupe from 'classnames/dedupe';
-import bind from 'classnames/bind';
+import classNames = require('classnames');
+import dedupe = require('classnames/dedupe');
+import bind = require('classnames/bind');
 
 // default
 classNames('foo');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "es2015",
+    "module": "commonjs",
     "lib": ["es2015"],
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
The package uses commonjs, but it’s typed as if it contains faux ESM. This was problematic for people using `require` or the new `node16` module resolution.