### PR TITLE
Use string concatenation, not arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@
 	var hasOwn = {}.hasOwnProperty;
 
 	function classNames() {
-		var classes = [];
+		var classes = "";
 
 		for (var i = 0; i < arguments.length; i++) {
 			var arg = arguments[i];
@@ -20,29 +20,29 @@
 			var argType = typeof arg;
 
 			if (argType === 'string' || argType === 'number') {
-				classes.push(arg);
+				classes += ' ' + arg;
 			} else if (Array.isArray(arg)) {
 				if (arg.length) {
 					var inner = classNames.apply(null, arg);
 					if (inner) {
-						classes.push(inner);
+						classes += ' ' + inner;
 					}
 				}
 			} else if (argType === 'object') {
 				if (arg.toString !== Object.prototype.toString && !arg.toString.toString().includes('[native code]')) {
-					classes.push(arg.toString());
+					classes += ' ' + arg;
 					continue;
 				}
 
 				for (var key in arg) {
 					if (hasOwn.call(arg, key) && arg[key]) {
-						classes.push(key);
+						classes += ' ' + key;
 					}
 				}
 			}
 		}
 
-		return classes.join(' ');
+		return classes.trimStart();
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
[It seems like string concatenation is more performant than array manipulation](https://www.measurethat.net/Benchmarks/ShowResult/343373), so I replaced `classes.push(` & `classes.join(' ')` with `classes += ' ' +arg` & `classes.trimStart()` in the core classnames function.

All tests are passing, no new features were added. so I didn't add any new tests.

jsperf.com from CONTRIBUTING.md doesn't work, so I tested on my machine and see massive performance gain in all cases:
(_local_ is the default, _my_ is the changed one)

```bash
* local#strings x 6,245,646 ops/sec ±1.00% (94 runs sampled)
* my#strings x 9,570,213 ops/sec ±2.59% (97 runs sampled)

> Fastest is my#strings

* local#object x 7,165,102 ops/sec ±4.42% (95 runs sampled)
* my#object x 12,929,752 ops/sec ±3.28% (99 runs sampled)

> Fastest is my#object

* local#strings, object x 5,413,534 ops/sec ±3.46% (90 runs sampled)
* my#strings, object x 7,503,844 ops/sec ±2.32% (86 runs sampled)

> Fastest is my#strings, object

* local#mix x 3,176,253 ops/sec ±2.91% (89 runs sampled)
* my#mix x 4,480,843 ops/sec ±2.08% (92 runs sampled)

> Fastest is my#mix

* local#arrays x 1,282,299 ops/sec ±1.22% (93 runs sampled)
* my#arrays x 2,133,194 ops/sec ±1.08% (96 runs sampled)

> Fastest is my#arrays
```