### PR TITLE
Support default export and UMD

### DIFF
--- a/bind.d.ts
+++ b/bind.d.ts
@@ -4,6 +4,14 @@ declare namespace classNames {
 	type Binding = Record<string, string>;
 }
 
-declare function classNames(this: classNames.Binding | undefined, ...args: ArgumentArray): string;
+interface ClassNames {
+	(this: classNames.Binding | undefined, ...args: ArgumentArray): string;
+
+	default: ClassNames;
+}
+
+declare const classNames: ClassNames;
+
+export as namespace classNames;
 
 export = classNames;

--- a/dedupe.d.ts
+++ b/dedupe.d.ts
@@ -1,2 +1,5 @@
 import classNames = require('./index.js');
+
+export as namespace classNames;
+
 export = classNames;

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,9 +15,17 @@ declare namespace classNames {
   type Argument = Value | Mapping | ArgumentArray;
 }
 
+interface ClassNames {
+	(...args: classNames.ArgumentArray): string;
+
+	default: ClassNames;
+}
+
 /**
  * A simple JavaScript utility for conditionally joining classNames together.
  */
-declare function classNames(...args: classNames.ArgumentArray): string;
+declare const classNames: ClassNames;
+
+export as namespace classNames;
 
 export = classNames;

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -3,6 +3,7 @@ import dedupe = require('classnames/dedupe');
 import bind = require('classnames/bind');
 
 // default
+classNames.default('foo');
 classNames('foo');
 classNames(null);
 classNames(undefined);
@@ -44,6 +45,7 @@ classNames({a: true}, 'b', 0);
 classNames({}, Infinity, [{}, []]);
 
 // dedupe
+dedupe.default('foo');
 dedupe('foo');
 dedupe(null);
 dedupe(undefined);
@@ -68,6 +70,7 @@ dedupe([Symbol()]);
 dedupe([[Symbol()]]);
 
 // bind
+bind.default.bind({foo: 'bar'});
 const bound = bind.bind({foo: 'bar'});
 bind.bind(undefined);
 // $ExpectError


### PR DESCRIPTION
It’s possible to support both a CJS export and a `.default` property by defining the export as an interface that has a call expression and a default property. This makes it possible to use `import classNames from 'classnames'` or `classNames.default('')`.

Also this packages exposes a UMD module, meaning `classNames` is available as a global when using a TypeScript script, but not when using a TypeScript module. This is supported by adding `export as namespace classNames`.

Technically this also declares it’s valid to use `classNames.default` when using `classNames` as a global. It may be better to move the line `classNames.default = classNames` outside of the if-statement at runtime.