### PR TITLE
(Typescript) Allow `ReadonlyArray`s as valid classNames parameters

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,8 @@ declare namespace classNames {
   type Value = string | number | boolean | undefined | null;
   type Mapping = Record<string, unknown>;
   interface ArgumentArray extends Array<Argument> {}
-  type Argument = Value | Mapping | ArgumentArray | ReadonlyArray<Argument>;
+  interface ReadonlyArgumentArray extends ReadonlyArray<Argument> {}
+  type Argument = Value | Mapping | ArgumentArray | ReadonlyArgumentArray;
 }
 
 interface ClassNames {

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare namespace classNames {
   type Value = string | number | boolean | undefined | null;
   type Mapping = Record<string, unknown>;
   interface ArgumentArray extends Array<Argument> {}
-  type Argument = Value | Mapping | ArgumentArray;
+  type Argument = Value | Mapping | ArgumentArray | ReadonlyArray<Argument>;
 }
 
 interface ClassNames {

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -20,6 +20,7 @@ classNames('bar', null, undefined, true, false, 1234);
 classNames('bar', ['abc', { foo: true }]);
 classNames('bar', ['abc', { foo: true }], { def: false, ijk: 1234 });
 classNames('abc', 1234, true, false, undefined, null, { foo: true }, ['abc', 1234, true, false, undefined, null, { foo: true }]);
+classNames('abc', 1234, true, false, undefined, null, { foo: true }, ['abc', 1234, true, false, undefined, null, { foo: true }], ['abc', 1234, true, false, undefined, null, { foo: true }] as const);
 // $ExpectError
 classNames(Symbol());
 // $ExpectError


### PR DESCRIPTION
Simple reproduction:
```typescript
const array = ['a', 'b', 'c'] as const;
classNames(array);
```
Error:
```
TS2345: Argument of type '[readonly ["a", "b", "c"]]' is not assignable to parameter of type 'ArgumentArray'.   Type 'readonly ["a", "b", "c"]' is not assignable to type 'Argument'.     Type 'readonly ["a", "b", "c"]' is not assignable to type 'Mapping'.       Index signature for type 'string' is missing in type 'readonly ["a", "b", "c"]'.
```

This PR adds a `ReadonlyArray<Argument>` to the `Argument` union type allowing `ReadonlyArray`s to be used with `classNames`