### PR TITLE
added join operation to type multi event classes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,10 +16,14 @@ declare namespace classNames {
   type Argument = Value | Mapping | ArgumentArray | ReadonlyArgumentArray;
 }
 
-interface ClassNames {
-	(...args: classNames.ArgumentArray): string;
+interface IJoin {
+  (key: string, ...args: classNames.ArgumentArray): string;
+}
 
-	default: ClassNames;
+interface ClassNames {
+  (...args: classNames.ArgumentArray): string;
+  join?: IJoin;
+  default: ClassNames;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -44,6 +44,18 @@
 
 		return classes.join(' ');
 	}
+	
+	classNames.join = function () {
+		const key = arguments[0];
+		if (!key || typeof key !== 'string') return '';
+		var args = [];
+		for (let i = 1; i < arguments.length; i++) {
+			args.push(arguments[i]);
+		}
+		var classes = classNames.apply(null, args);
+		return key + classes.split(' ').join(' ' + key)
+	}
+
 
 	if (typeof module !== 'undefined' && module.exports) {
 		classNames.default = classNames;

--- a/tests/index.js
+++ b/tests/index.js
@@ -21,7 +21,7 @@ describe('classNames', function () {
 	});
 
 	it('supports heterogenous arguments', function () {
-		assert.equal(classNames({a: true}, 'b', 0), 'a b');
+		assert.equal(classNames({ a: true }, 'b', 0), 'a b');
 	});
 
 	it('should be trimmed', function () {
@@ -54,11 +54,11 @@ describe('classNames', function () {
 	});
 
 	it('handles arrays that include objects', function () {
-		assert.equal(classNames(['a', {b: true, c: false}]), 'a b');
+		assert.equal(classNames(['a', { b: true, c: false }]), 'a b');
 	});
 
 	it('handles deep array recursion', function () {
-		assert.equal(classNames(['a', ['b', ['c', {d: true}]]]), 'a b c d');
+		assert.equal(classNames(['a', ['b', ['c', { d: true }]]]), 'a b c d');
 	});
 
 	it('handles arrays that are empty', function () {
@@ -85,7 +85,7 @@ describe('classNames', function () {
 			whitespace: ' ',
 			function: Object.prototype.toString,
 			emptyObject: {},
-			nonEmptyObject: {a: 1, b: 2},
+			nonEmptyObject: { a: 1, b: 2 },
 			emptyList: [],
 			nonEmptyList: [1, 2, 3],
 			greaterZero: 1
@@ -99,9 +99,9 @@ describe('classNames', function () {
 	});
 
 	it('handles toString() method defined inherited in object', function () {
-		var Class1 = function() {};
-		var Class2 = function() {};
-		Class1.prototype.toString = function() { return 'classFromMethod'; }
+		var Class1 = function () { };
+		var Class2 = function () { };
+		Class1.prototype.toString = function () { return 'classFromMethod'; }
 		Class2.prototype = Object.create(Class1.prototype);
 
 		assert.equal(classNames(new Class2()), 'classFromMethod');
@@ -116,4 +116,23 @@ describe('classNames', function () {
 		vm.runInContext(code, context);
 		assert.equal(context.output, 'a b');
 	});
+
+	it('handles join operations', function () {
+		assert.equal(classNames(
+			'a',
+			classNames.join('hover:',
+				{
+					'b': true,
+				},
+				['c', 'd']
+			),
+			[classNames.join('sm:', {
+				"h-max": true,
+				"bg-red-500": true,
+			})]
+		), 'a hover:b hover:c hover:d sm:h-max sm:bg-red-500');
+	});
+
+
+
 });


### PR DESCRIPTION
Hi. firstly thanks to create this package. This is my first pull-request and in advance i am sorry for all my mistakes.
most people use classnames to write conditional tailwind classes. With tailwind css we cant specify multiple class to a spesific evente. I also added a complex test to see better.
For ex.
"hover:[more than one styles]"  X not allowed.
we want to be able to write more than one styles.

join func takes styles args and sends to cs(...styles)  
(cs( cs.join("hover",...styles) ) ) 

