### PR TITLE
Fixes #313

### DIFF
--- a/bind.js
+++ b/bind.js
@@ -37,12 +37,7 @@
 			}
 		}
 
-		var totalClasses = classes.join(' ');
-
-		if (totalClasses.length > 0) {
-			return totalClasses;
-		}
-		return null;
+		return classes.join(' ') || null;
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {

--- a/bind.js
+++ b/bind.js
@@ -37,7 +37,12 @@
 			}
 		}
 
-		return classes.join(' ');
+		var totalClasses = classes.join(' ');
+
+		if (totalClasses.length > 0) {
+			return totalClasses;
+		}
+		return null;
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {

--- a/dedupe.js
+++ b/dedupe.js
@@ -95,7 +95,12 @@
 				}
 			}
 
-			return list.join(' ');
+			var totalList = list.join(' ');
+
+			if (totalList.length) {
+				return totalList;
+			}
+			return null;
 		}
 
 		return _classNames;

--- a/dedupe.js
+++ b/dedupe.js
@@ -94,13 +94,8 @@
 					list.push(k)
 				}
 			}
-
-			var totalList = list.join(' ');
-
-			if (totalList.length) {
-				return totalList;
-			}
-			return null;
+			
+			return list.join(' ') || null;
 		}
 
 		return _classNames;

--- a/dedupe.js
+++ b/dedupe.js
@@ -94,7 +94,7 @@
 					list.push(k)
 				}
 			}
-			
+
 			return list.join(' ') || null;
 		}
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,12 @@
 			}
 		}
 
-		return classes.join(' ');
+		var totalClasses = classes.join(' ');
+
+		if (totalClasses.length > 0) {
+			return totalClasses;
+		}
+		return null;
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {

--- a/index.js
+++ b/index.js
@@ -42,12 +42,7 @@
 			}
 		}
 
-		var totalClasses = classes.join(' ');
-
-		if (totalClasses.length > 0) {
-			return totalClasses;
-		}
-		return null;
+		return classes.join(' ') || null;
 	}
 
 	if (typeof module !== 'undefined' && module.exports) {

--- a/tests/bind.js
+++ b/tests/bind.js
@@ -39,8 +39,8 @@ describe('bind', function () {
 			assert.equal(classNames('', 'b', {}, ''), 'b');
 		});
 
-		it('returns an empty string for an empty configuration', function () {
-			assert.equal(classNames({}), '');
+		it('returns a null for an empty configuration', function () {
+			assert.equal(classNames({}), null);
 		});
 
 		it('supports an array of class names', function () {
@@ -115,8 +115,8 @@ describe('bind', function () {
 			assert.equal(classNamesBound('', 'b', {}, ''), '#b');
 		});
 
-		it('returns an empty string for an empty configuration', function () {
-			assert.equal(classNamesBound({}), '');
+		it('returns a null for an empty configuration', function () {
+			assert.equal(classNamesBound({}), null);
 		});
 
 		it('supports an array of class names', function () {

--- a/tests/dedupe.js
+++ b/tests/dedupe.js
@@ -42,8 +42,8 @@ describe('dedupe', function () {
 		assert.equal(dedupe('', 'b', {}, ''), 'b');
 	});
 
-	it('returns an empty string for an empty configuration', function () {
-		assert.equal(dedupe({}), '');
+	it('returns a null for an empty configuration', function () {
+		assert.equal(dedupe({}), null);
 	});
 
 	it('supports an array of class names', function () {

--- a/tests/index.js
+++ b/tests/index.js
@@ -28,8 +28,8 @@ describe('classNames', function () {
 		assert.equal(classNames('', 'b', {}, ''), 'b');
 	});
 
-	it('returns an empty string for an empty configuration', function () {
-		assert.equal(classNames({}), '');
+	it('returns a null for an empty configuration', function () {
+		assert.equal(classNames({}), null);
 	});
 
 	it('supports an array of class names', function () {


### PR DESCRIPTION
**Changes:**
- If the final set of classes is empty, the function returns null instead of an empty string
In this case, if we specify a class via className, the html will not display the empty class attribute.
- Adjusted the tests for this change

**All the tests pass**

**Benchmark results:**
![image](https://github.com/JedWatson/classnames/assets/43030787/16b3f9d7-b830-40ab-b835-582d6a9dfd82)

Closes #313