### PR TITLE
Update Node.js version matrix on CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 17.x, 18.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [18, 20, 21]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/previous-releases
 
     steps:
     - uses: actions/checkout@main
@@ -35,6 +35,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: lts/*
+        node-version: 20
     - run: npm ci
     - run: npm run dtslint


### PR DESCRIPTION
Updates the Node.js version matrix on CI with the [actively supported versions](https://nodejs.org/en/about/previous-releases).