### PR TITLE
Remove `bower.json` from `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,5 @@
 /.*
 /benchmarks/
 /tests/
-/bower.json
 /CONTRIBUTING.md
 /HISTORY.md


### PR DESCRIPTION
This file no longer exists, so there is no need to ignore it.