### PR TITLE
Use modern JavaScript syntax for benchmarks

### DIFF
--- a/benchmarks/fixtures.js
+++ b/benchmarks/fixtures.js
@@ -1,4 +1,4 @@
-var fixtures = [
+const fixtures = [
 	{
 		description: 'strings',
 		args: ['one', 'two', 'three'],
@@ -26,4 +26,4 @@ var fixtures = [
 	}
 ];
 
-module.exports = fixtures;
+export default fixtures;

--- a/benchmarks/index.html
+++ b/benchmarks/index.html
@@ -5,8 +5,8 @@
 		<title>Benchmarks</title>
 	</head>
 	<body>
-		<div id="results"></div>
-		<div id="loader">Wait please&hellip;</div>
-		<script src="runInBrowser.bundle.js"></script>
+		<button id="start" type="button" disabled>Start benchmarks</button>
+		<pre id="results"></pre>
+		<script type="module" src="./runInBrowser.bundle.js"></script>
 	</body>
 </html>

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -1,8 +1,9 @@
 {
   "name": "classnames-benchmarks",
+  "type": "module",
   "scripts": {
     "benchmarks": "node ./run.js",
-    "benchmarks-browser": "rollup --plugin commonjs,json,node-resolve ./runInBrowser.js --file ./runInBrowser.bundle.js --format iife && http-server -o"
+    "benchmarks-browser": "rollup --plugin commonjs,json,node-resolve ./runInBrowser.js --file ./runInBrowser.bundle.js && http-server -o -c-1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -1,33 +1,29 @@
-var fixtures = require('./fixtures');
-var local = require('classnames-local');
-var dedupe = require('classnames-local/dedupe');
-var localPackage = require('classnames-local/package.json');
+import local from 'classnames-local';
+import dedupe from 'classnames-local/dedupe.js';
+import localPackage from 'classnames-local/package.json' with { type: 'json' };
+
+import npm from 'classnames-npm';
+import npmDedupe from 'classnames-npm/dedupe.js';
+import npmPackage from 'classnames-npm/package.json' with { type: 'json' };
+
+import fixtures from './fixtures.js';
+import runChecks from './runChecks.js';
+import runSuite from './runSuite.js';
+
+if (localPackage.version !== npmPackage.version) {
+	log(
+		`Your local version (${localPackage.version} does not match the installed version (${npmPackage.version})\n\n` +
+		'Please run `npm update classnames-npm` in ./benchmarks to ensure you are benchmarking\n' +
+		'the latest version of this package.\n'
+	);
+	process.exit(0);
+}
+
+fixtures.forEach((f) => {
+	runChecks(local, npm, dedupe, npmDedupe, f);
+	runSuite(local, npm, dedupe, npmDedupe, f, log);
+});
 
 function log (message) {
 	console.log(message);
 }
-
-try {
-	var npm = require('classnames-npm');
-	var npmDedupe = require('classnames-npm/dedupe');
-	var npmPackage = require('classnames-npm/package.json');
-} catch (e) {
-	log('There was an error loading the benchmark classnames package.\n' +
-		'Please make sure you have run `npm install` in ./benchmarks\n');
-	process.exit(0);
-}
-
-if (localPackage.version !== npmPackage.version) {
-	log('Your local version (' + localPackage.version + ') does not match the installed version (' + npmPackage.version + ')\n\n' +
-		'Please run `npm update classnames-npm` in ./benchmarks to ensure you are benchmarking\n' +
-		'the latest version of this package.\n');
-	process.exit(0);
-}
-
-var runChecks = require('./runChecks');
-var runSuite = require('./runSuite');
-
-fixtures.forEach(function (f) {
-	runChecks(local, npm, dedupe, npmDedupe, f);
-	runSuite(local, npm, dedupe, npmDedupe, f, log);
-});

--- a/benchmarks/runChecks.js
+++ b/benchmarks/runChecks.js
@@ -1,15 +1,15 @@
-var assert = require('assert');
+import assert from 'node:assert/strict';
 
 function sortClasses (str) {
 	return str.split(' ').sort().join(' ');
 }
 
 function runChecks (local, npm, dedupe, npmDedupe, fixture) {
-	// sort assertions because dedupe returns results in a different order
-	assert.equal(sortClasses(local.apply(null, fixture.args)), sortClasses(fixture.expected));
-	assert.equal(sortClasses(dedupe.apply(null, fixture.args)), sortClasses(fixture.expected));
-	assert.equal(sortClasses(npm.apply(null, fixture.args)), sortClasses(fixture.expected));
-	assert.equal(sortClasses(npmDedupe.apply(null, fixture.args)), sortClasses(fixture.expected));
+	// Sort assertions because 'dedupe' returns results in a different order.
+	assert.equal(sortClasses(local(...fixture.args)), sortClasses(fixture.expected));
+	assert.equal(sortClasses(dedupe(...fixture.args)), sortClasses(fixture.expected));
+	assert.equal(sortClasses(npm(...fixture.args)), sortClasses(fixture.expected));
+	assert.equal(sortClasses(npmDedupe(...fixture.args)), sortClasses(fixture.expected));
 }
 
-module.exports = runChecks;
+export default runChecks;

--- a/benchmarks/runInBrowser.js
+++ b/benchmarks/runInBrowser.js
@@ -1,50 +1,52 @@
-var fixtures = require('./fixtures');
-var local = require('classnames-local');
-var dedupe = require('classnames-local/dedupe');
-var localPackage = require('classnames-local/package.json');
+import local from 'classnames-local';
+import dedupe from 'classnames-local/dedupe.js';
+import localPackage from 'classnames-local/package.json' with { type: 'json' };
 
-var npm = require('classnames-npm');
-var npmDedupe = require('classnames-npm/dedupe');
-var npmPackage = require('classnames-npm/package.json');
+import npm from 'classnames-npm';
+import npmDedupe from 'classnames-npm/dedupe.js';
+import npmPackage from 'classnames-npm/package.json' with { type: 'json' };
+
+import fixtures from './fixtures.js';
+import runSuite from './runSuite.js';
+
+const startButton = document.getElementById('start');
+const results = document.getElementById('results');
+
+startButton.addEventListener('click', runBenchmarks);
+
+if (localPackage.version === npmPackage.version) {
+	startButton.disabled = false;
+} else {
+	startButton.style.display = 'none';
+
+	log(
+		`Your local version (${localPackage.version} does not match the installed version (${npmPackage.version})\n\n` +
+		'Please run `npm update classnames-npm` in ./benchmarks to ensure you are benchmarking\n' +
+		'the latest version of this package.\n'
+	);
+}
+
+async function runBenchmarks () {
+	startButton.style.display = 'none';
+
+	log('Running benchmark…');
+	log(navigator.userAgent);
+
+	await nextTick();
+
+	for (const fixture of fixtures) {
+		runSuite(local, npm, dedupe, npmDedupe, fixture, log);
+		await nextTick();
+	}
+
+	log('Finished!');
+}
 
 function log (message) {
 	console.log(message);
-	var results = document.getElementById('results');
-	//noinspection InnerHTMLJS
-	results.innerHTML += (message + '\n').replace(/\n/g, '<br/>');
+	results.textContent += `${message}\n`;
 }
 
-if (localPackage.version !== npmPackage.version) {
-	log('Your local version (' + localPackage.version + ') does not match the installed version (' + npmPackage.version + ')\n\n' +
-		'Please run `npm update classnames-npm` in ./benchmarks to ensure you are benchmarking\n' +
-		'the latest version of this package.\n');
-	return;
+function nextTick () {
+	return new Promise((resolve) => setTimeout(resolve));
 }
-
-function iterate (array, iterator, i, callback) {
-	if (i >= 0 && i < array.length) {
-		iterator(array[i], i, array);
-		setTimeout(iterate.bind(null, array, iterator, i + 1, callback), 1);
-	} else if (callback) {
-		callback();
-	}
-}
-
-function deferredForEach (array, iterator, callback) {
-	iterate(array, iterator, 0, callback);
-}
-
-var runSuite = require('./runSuite');
-
-window.onload = function () {
-	//noinspection PlatformDetectionJS
-	log(navigator.userAgent);
-	setTimeout(function () {
-		deferredForEach(fixtures, function (f) {
-			runSuite(local, npm, dedupe, npmDedupe, f, log);
-		}, function () {
-			log('Finished');
-			document.getElementById('loader').style.display = 'none';
-		});
-	}, 100);
-};

--- a/benchmarks/runSuite.js
+++ b/benchmarks/runSuite.js
@@ -1,38 +1,36 @@
-var benchmark = require('benchmark');
-var _ = require('lodash');
+import benchmark from 'benchmark';
+import _ from 'lodash';
 
-var Suite = benchmark.runInContext({ _ }).Suite;
+const { Suite } = benchmark.runInContext({ _ });
 
 function runSuite (local, npm, dedupe, npmDedupe, fixture, log) {
-	var suite = new Suite();
+	const suite = new Suite();
 
-	suite.add('local#' + fixture.description, function () {
-		local.apply(null, fixture.args);
+	suite.add(`local#${fixture.description}`, () => {
+		local(...fixture.args);
 	});
 
-	suite.add('  npm#' + fixture.description, function () {
-		npm.apply(null, fixture.args);
+	suite.add(`  npm#${fixture.description}`, () => {
+		npm(...fixture.args);
 	});
 
-	suite.add('local/dedupe#' + fixture.description, function () {
-		dedupe.apply(null, fixture.args);
+	suite.add(`local/dedupe#${fixture.description}`, () => {
+		dedupe(...fixture.args);
 	});
 
-	suite.add('  npm/dedupe#' + fixture.description, function () {
-		npmDedupe.apply(null, fixture.args);
+	suite.add(`  npm/dedupe#${fixture.description}`, () => {
+		npmDedupe(...fixture.args);
 	});
 
-	// after each cycle
-	suite.on('cycle', function (event) {
-		log('* ' + String(event.target));
+	suite.on('cycle', (event) => {
+		log(`* ${event.target}`);
 	});
 
-	// other handling
-	suite.on('complete', function () {
-		log('\n> Fastest is' + (' ' + this.filter('fastest').map(result => result.name).join(' | ')).replace(/\s+/, ' ') + '\n');
+	suite.on('complete', () => {
+		log(`\n> Fastest is ${(suite.filter('fastest').map(result => result.name).join(' | ')).replace(/\s+/, ' ')}\n`);
 	});
 
-	suite.on('error', function (event) {
+	suite.on('error', (event) => {
 		log(event.target.error.message);
 		throw event.target.error;
 	});
@@ -40,4 +38,4 @@ function runSuite (local, npm, dedupe, npmDedupe, fixture, log) {
 	suite.run();
 }
 
-module.exports = runSuite;
+export default runSuite;


### PR DESCRIPTION
Changes the benchmark code so that modern JavaScript syntax is used where possible, including modules.