### PR TITLE
Restore ability to pass TypeScript `interface`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@
 
 declare namespace classNames {
   type Value = string | number | boolean | undefined | null;
-  type Mapping = Record<string, unknown>;
+  type Mapping = Record<string, any>;
   interface ArgumentArray extends Array<Argument> {}
   interface ReadonlyArgumentArray extends ReadonlyArray<Argument> {}
   type Argument = Value | Mapping | ArgumentArray | ReadonlyArgumentArray;

--- a/tests/bind.test-d.ts
+++ b/tests/bind.test-d.ts
@@ -1,6 +1,18 @@
 import {expectError} from 'tsd';
 import bind from '../bind';
 
+type Foo = {
+  bar: boolean;
+};
+
+const foo: Foo = { bar: true };
+
+interface IFoo {
+  bar: boolean;
+}
+
+const ifoo: IFoo = { bar: true };
+
 // bind
 bind.default.bind({foo: 'bar'});
 const bound = bind.bind({foo: 'bar'});
@@ -22,6 +34,6 @@ bound('bar', null, undefined, true, false, 1234);
 bound('bar', ['abc', { foo: true }]);
 bound('bar', ['abc', { foo: true }], { def: false, ijk: 1234 });
 bound('abc', 1234, true, false, undefined, null, { foo: true }, ['abc', 1234, true, false, undefined, null, { foo: true }]);
+bound(foo);
+bound(ifoo);
 expectError(bound(Symbol()));
-expectError(bound([Symbol()]));
-expectError(bound([[Symbol()]]));

--- a/tests/dedupe.test-d.ts
+++ b/tests/dedupe.test-d.ts
@@ -1,6 +1,18 @@
 import {expectError} from 'tsd';
 import dedupe from '../dedupe';
 
+type Foo = {
+  bar: boolean;
+};
+
+const foo: Foo = { bar: true };
+
+interface IFoo {
+  bar: boolean;
+}
+
+const ifoo: IFoo = { bar: true };
+
 // dedupe
 dedupe.default('foo');
 dedupe('foo');
@@ -19,6 +31,6 @@ dedupe('bar', null, undefined, true, false, 1234);
 dedupe('bar', ['abc', { foo: true }]);
 dedupe('bar', ['abc', { foo: true }], { def: false, ijk: 1234 });
 dedupe('abc', 1234, true, false, undefined, null, { foo: true }, ['abc', 1234, true, false, undefined, null, { foo: true }]);
+dedupe(foo);
+dedupe(ifoo);
 expectError(dedupe(Symbol()));
-expectError(dedupe([Symbol()]));
-expectError(dedupe([[Symbol()]]));

--- a/tests/index.test-d.ts
+++ b/tests/index.test-d.ts
@@ -1,6 +1,18 @@
 import {expectError} from 'tsd';
 import classNames from '..';
 
+type Foo = {
+  bar: boolean;
+};
+
+const foo: Foo = { bar: true };
+
+interface IFoo {
+  bar: boolean;
+}
+
+const ifoo: IFoo = { bar: true };
+
 // default
 classNames.default('foo');
 classNames('foo');
@@ -20,11 +32,9 @@ classNames('bar', ['abc', { foo: true }]);
 classNames('bar', ['abc', { foo: true }], { def: false, ijk: 1234 });
 classNames('abc', 1234, true, false, undefined, null, { foo: true }, ['abc', 1234, true, false, undefined, null, { foo: true }]);
 classNames('abc', 1234, true, false, undefined, null, { foo: true }, ['abc', 1234, true, false, undefined, null, { foo: true }], ['abc', 1234, true, false, undefined, null, { foo: true }] as const);
-
+classNames(foo);
+classNames(ifoo);
 expectError(classNames(Symbol()));
-expectError(classNames([Symbol()]));
-expectError(classNames([[Symbol()]]));
-
 // should match tests/index.js
 classNames('c', ['a', 'b']);
 classNames('', 'b', {}, '');


### PR DESCRIPTION
Closes #294, as per https://github.com/JedWatson/classnames/issues/294#issuecomment-1870466528