### PR TITLE
Fix URL for GIT repository in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/JedWatson/classnames.git"
+    "url": "git+https://github.com/JedWatson/classnames.git"
   },
   "type": "commonjs",
   "main": "./index.js",


### PR DESCRIPTION
Fixes some warnings emitted by `npm publish`:
```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository.url" was normalized to "git+https://github.com/JedWatson/classnames.git"
```