### PR TITLE
Clean up and modernize code for dedupe

### DIFF
--- a/tests/dedupe.js
+++ b/tests/dedupe.js
@@ -30,7 +30,7 @@ describe('dedupe', () => {
 	});
 
 	it('joins arrays of class names and ignore falsy values', () => {
-		assert.equal(dedupe('a', 0, null, undefined, true, 1, 'b'), '1 a b');
+		assert.equal(dedupe('a', 0, null, undefined, true, 1, 'b'), 'a 1 b');
 	});
 
 	it('supports heterogenous arguments', () => {


### PR DESCRIPTION
Cleans up the code for dedupe so that it better matches the structure of the other variants. Also introduces `Set` to de-duplicate classes. Benchmarks seem to indicate it's slightly faster, especially for mixed test cases:

<details>
<summary>Node.js (v21.5.0)</summary>

Benchmarking 'strings'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 4,045,085 | 247.2135826039219  | ±0.56% | 2022543 |
| dedupe/npm   | 4,042,492 | 247.37213314357965 | ±0.52% | 2021247 |

Benchmarking 'object'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 7,221,118 | 138.48269326646596 | ±0.59% | 3610560 |
| dedupe/npm   | 6,935,808 | 144.1793010477904  | ±0.29% | 3467905 |

Benchmarking 'strings, object'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 4,415,599 | 226.46980115941534 | ±0.21% | 2207800 |
| dedupe/npm   | 4,096,954 | 244.08371678890256 | ±0.74% | 2048478 |

Benchmarking 'mix'.

| Task Name    | ops/sec   | Average Time (ns) | Margin | Samples |
| ------------ | --------- | ----------------- | ------ | ------- |
| dedupe/local | 3,083,596 | 324.2966677236706 | ±0.74% | 1541799 |
| dedupe/npm   | 1,935,753 | 516.594635475142  | ±0.76% | 967877  |

Benchmarking 'arrays'.

| Task Name    | ops/sec   | Average Time (ns) | Margin | Samples |
| ------------ | --------- | ----------------- | ------ | ------- |
| dedupe/local | 1,921,840 | 520.3345623628504 | ±0.39% | 960921  |
| dedupe/npm   | 1,888,877 | 529.4150696866383 | ±0.95% | 944439  |
</details>