### PR TITLE
Clean up dedupe to better match other entrypoints

### DIFF
--- a/dedupe.js
+++ b/dedupe.js
@@ -1,94 +1,85 @@
-const classNames = (function () {
-	// don't inherit from Object so we can skip hasOwnProperty check later
-	// http://stackoverflow.com/questions/15518328/creating-js-object-with-object-createnull#answer-21079232
-	function StorageObject() {}
-	StorageObject.prototype = Object.create(null);
+// Don't inherit from Object so we can skip hasOwnProperty check later.
+function StorageObject () {}
+StorageObject.prototype = Object.create(null);
 
-	function _parseArray (resultSet, array) {
-		const length = array.length;
+export default function classNames () {
+	// Don't leak arguments.
+	// https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
+	const length = arguments.length;
+	const args = Array(length);
 
-		for (let i = 0; i < length; ++i) {
-			_parse(resultSet, array[i]);
+	for (let i = 0; i < length; i++) {
+		args[i] = arguments[i];
+	}
+
+	const classSet = new StorageObject();
+	appendArray(classSet, args);
+
+	const list = [];
+
+	for (const k in classSet) {
+		if (classSet[k]) {
+			list.push(k);
 		}
 	}
 
-	const hasOwn = {}.hasOwnProperty;
+	return list.join(' ');
+}
 
-	function _parseNumber (resultSet, num) {
-		resultSet[num] = true;
+function appendValue (classSet, arg) {
+	if (!arg) return;
+	const argType = typeof arg;
+
+	if (argType === 'string') {
+		appendString(classSet, arg);
+	} else if (Array.isArray(arg)) {
+		appendArray(classSet, arg);
+	} else if (argType === 'object') {
+		appendObject(classSet, arg);
+	} else if (argType === 'number') {
+		appendNumber(classSet, arg);
+	}
+}
+
+const SPACE = /\s+/;
+
+function appendString (classSet, str) {
+	const array = str.split(SPACE);
+	const length = array.length;
+
+	for (let i = 0; i < length; i++) {
+		classSet[array[i]] = true;
+	}
+}
+
+function appendArray (classSet, array) {
+	const length = array.length;
+
+	for (let i = 0; i < length; i++) {
+		appendValue(classSet, array[i]);
+	}
+}
+
+function appendNumber (classSet, num) {
+	classSet[num] = true;
+}
+
+const hasOwn = {}.hasOwnProperty;
+
+function appendObject (classSet, object) {
+	if (
+		object.toString !== Object.prototype.toString &&
+		!object.toString.toString().includes('[native code]')
+	) {
+		classSet[object.toString()] = true;
+		return;
 	}
 
-	function _parseObject (resultSet, object) {
-		if (object.toString !== Object.prototype.toString && !object.toString.toString().includes('[native code]')) {
-			resultSet[object.toString()] = true;
-			return;
-		}
-
-		for (const k in object) {
-			if (hasOwn.call(object, k)) {
-				// set value to false instead of deleting it to avoid changing object structure
-				// https://www.smashingmagazine.com/2012/11/writing-fast-memory-efficient-javascript/#de-referencing-misconceptions
-				resultSet[k] = !!object[k];
-			}
+	for (const k in object) {
+		if (hasOwn.call(object, k)) {
+			// Set value to false instead of deleting it to avoid changing object structure.
+			// https://www.smashingmagazine.com/2012/11/writing-fast-memory-efficient-javascript/#de-referencing-misconceptions
+			classSet[k] = !!object[k];
 		}
 	}
-
-	const SPACE = /\s+/;
-	function _parseString (resultSet, str) {
-		const array = str.split(SPACE);
-		const length = array.length;
-
-		for (let i = 0; i < length; ++i) {
-			resultSet[array[i]] = true;
-		}
-	}
-
-	function _parse (resultSet, arg) {
-		if (!arg) return;
-		const argType = typeof arg;
-
-		// 'foo bar'
-		if (argType === 'string') {
-			_parseString(resultSet, arg);
-
-		// ['foo', 'bar', ...]
-		} else if (Array.isArray(arg)) {
-			_parseArray(resultSet, arg);
-
-		// { 'foo': true, ... }
-		} else if (argType === 'object') {
-			_parseObject(resultSet, arg);
-
-		// '130'
-		} else if (argType === 'number') {
-			_parseNumber(resultSet, arg);
-		}
-	}
-
-	function _classNames () {
-		// don't leak arguments
-		// https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
-		const length = arguments.length;
-		const args = Array(length);
-		for (let i = 0; i < length; i++) {
-			args[i] = arguments[i];
-		}
-
-		const classSet = new StorageObject();
-		_parseArray(classSet, args);
-
-		const list = [];
-
-		for (const k in classSet) {
-			if (classSet[k]) {
-				list.push(k)
-			}
-		}
-
-		return list.join(' ');
-	}
-
-	return _classNames;
-})();
-
-export default classNames;
+}


### PR DESCRIPTION
Cleans up the code for the 'dedupe' variant to better match the code-style of the other entrypoints. This removes the immediately invoked function expression that was used to prevent variables from leaking into the global scope, as this is no longer possible now that this code is contained in a module.

This also sorts some methods and renames some variables, but otherwise doesn't touch the code, leading to similar performance to what we had before.