### PR TITLE
Do not clone `arguments` in dedupe

### DIFF
--- a/dedupe.js
+++ b/dedupe.js
@@ -3,17 +3,8 @@ function StorageObject () {}
 StorageObject.prototype = Object.create(null);
 
 export default function classNames () {
-	// Don't leak arguments.
-	// https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
-	const length = arguments.length;
-	const args = Array(length);
-
-	for (let i = 0; i < length; i++) {
-		args[i] = arguments[i];
-	}
-
 	const classSet = new StorageObject();
-	appendArray(classSet, args);
+	appendArray(classSet, arguments);
 
 	const list = [];
 


### PR DESCRIPTION
Removes the code that clones the `arguments` for the dedupe variant, instead opting to pass it directly to the function that parses it as an array, reducing the amount of code required.

## Benchmarks (compared to `main`)

This seems to net slightly improved or similar performance under Node.js, Chrome and Safari, with only a small performance loss in Firefox (mostly within margin of error). The following benchmarks were ran on my 2021 MacBook Pro 14-inch with an M1 Pro chip running macOS Sonoma (14.2.1):

<details>
<summary>Node.js (v21.5.0)</summary>

Benchmarking 'strings'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 4,162,768 | 240.22472536300643 | ±0.62% | 2081385 |
| dedupe/main  | 3,995,954 | 250.25309688105878 | ±0.51% | 1997978 |

Benchmarking 'object'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 7,092,130 | 141.00134684470765 | ±0.52% | 3546066 |
| dedupe/main  | 7,024,786 | 142.35308083317503 | ±0.19% | 3512394 |

Benchmarking 'strings, object'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 4,289,936 | 233.10367515856322 | ±0.54% | 2144969 |
| dedupe/main  | 4,042,380 | 247.37897309069996 | ±0.87% | 2021191 |

Benchmarking 'mix'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 1,973,947 | 506.5990704930089  | ±0.61% | 986974  |
| dedupe/main  | 1,956,537 | 511.10701453269826 | ±0.40% | 978269  |

Benchmarking 'arrays'.

| Task Name    | ops/sec   | Average Time (ns) | Margin | Samples |
| ------------ | --------- | ----------------- | ------ | ------- |
| dedupe/local | 1,920,654 | 520.6557801077598 | ±0.48% | 960328  |
| dedupe/main  | 1,922,432 | 520.1742093626303 | ±0.53% | 961217  |
</details>

<details>
<summary>Chrome (v120.0.6099.129)</summary>
Benchmarking 'strings'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 2,804,055 | 356.62625853539487 | ±2.81% | 1402028 |
| dedupe/main  | 2,908,971 | 343.7640513632829  | ±2.77% | 1454486 |

Benchmarking 'object'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 4,367,546 | 228.96150095099688 | ±2.77% | 2184210 |
| dedupe/main  | 4,331,419 | 230.87118439853185 | ±2.77% | 2166143 |

Benchmarking 'strings, object'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 3,050,469 | 327.8183462829238  | ±2.79% | 1525540 |
| dedupe/main  | 3,039,449 | 329.00689269685324 | ±2.77% | 1519725 |

Benchmarking 'mix'.

| Task Name    | ops/sec   | Average Time (ns) | Margin | Samples |
| ------------ | --------- | ----------------- | ------ | ------- |
| dedupe/local | 1,854,643 | 539.1873053124684 | ±2.77% | 927507  |
| dedupe/main  | 1,817,214 | 550.2927522205538 | ±2.77% | 908789  |

Benchmarking 'arrays'.

| Task Name    | ops/sec   | Average Time (ns) | Margin | Samples |
| ------------ | --------- | ----------------- | ------ | ------- |
| dedupe/local | 1,691,219 | 591.2892138331515 | ±2.78% | 845779  |
| dedupe/main  | 1,696,507 | 589.4460857331065 | ±2.77% | 848254  |
</details>

<details>
<summary>Safari (v17.2.1)</summary>

Benchmarking 'strings'.

| Task Name    | ops/sec   | Average Time (ns) | Margin | Samples |
| ------------ | --------- | ----------------- | ------ | ------- |
| dedupe/local | 1,934,806 | 516.8475805136814 | ±8.75% | 969338  |
| dedupe/main  | 1,909,468 | 523.706079389652  | ±8.76% | 954734  |

Benchmarking 'object'. (runInBrowser.bundle.js, line 950)

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 3,263,985 | 306.37386312318966 | ±8.76% | 1631993 |
| dedupe/main  | 3,095,159 | 323.0850747618863  | ±8.76% | 1547580 |

Benchmarking 'strings, object'. (runInBrowser.bundle.js, line 950)

| Task Name    | ops/sec   | Average Time (ns) | Margin | Samples |
| ------------ | --------- | ----------------- | ------ | ------- |
| dedupe/local | 1,874,589 | 533.4499810625373 | ±8.76% | 937295  |
| dedupe/main  | 1,807,921 | 553.1212076627522 | ±8.76% | 903961  |

Benchmarking 'mix'. (runInBrowser.bundle.js, line 950)

| Task Name    | ops/sec   | Average Time (ns) | Margin | Samples |
| ------------ | --------- | ----------------- | ------ | ------- |
| dedupe/local | 1,166,299 | 857.4123295893555 | ±8.76% | 583150  |
| dedupe/main  | 1,162,307 | 860.3571514607269 | ±8.76% | 581154  |

Benchmarking 'arrays'. (runInBrowser.bundle.js, line 950)

| Task Name    | ops/sec | Average Time (ns)  | Margin | Samples |
| ------------ | ------- | ------------------ | ------ | ------- |
| dedupe/local | 830,693 | 1203.8127156329704 | ±8.76% | 415347  |
| dedupe/main  | 799,766 | 1250.365001759423  | ±8.75% | 400683  |
</details>

<details>
<summary>Firefox (v121.0)</summary>

Benchmarking 'strings'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 3.536.708 | 282.74881613070687 | ±8.76% | 1768354 |
| dedupe/main  | 3.694.294 | 270.6877146215217  | ±8.76% | 1847147 |

Benchmarking 'object'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 5.733.282 | 174.4201663200938  | ±8.76% | 2866641 |
| dedupe/main  | 5.950.638 | 168.04920749674238 | ±8.76% | 2975319 |

Benchmarking 'strings, object'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 3.984.366 | 250.98095907855856 | ±8.76% | 1992183 |
| dedupe/main  | 4.026.326 | 248.36538323026997 | ±8.76% | 2013163 |

Benchmarking 'mix'.

| Task Name    | ops/sec   | Average Time (ns)  | Margin | Samples |
| ------------ | --------- | ------------------ | ------ | ------- |
| dedupe/local | 2.001.542 | 499.61479699151954 | ±9.44% | 1000771 |
| dedupe/main  | 2.033.008 | 491.88197980529344 | ±9.11% | 1016504 |

Benchmarking 'arrays'.

| Task Name    | ops/sec   | Average Time (ns) | Margin | Samples |
| ------------ | --------- | ----------------- | ------ | ------- |
| dedupe/local | 1.744.158 | 573.3425526815804 | ±8.76% | 872079  |
| dedupe/main  | 1.774.168 | 563.6444801168773 | ±8.76% | 887084  |
</details>