### PR TITLE
Refactored index.js to reduce bundle size by 30%

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 export default function classNames(...args) {
 	return args
 		.map((arg) => {
-			// falsy value: undefined | null | false | 0 | ""
-			if (!arg) {
-				return "";
-			}
-
 			// string: "a"
 			if (typeof arg === "string") {
 				return arg;
+			}
+
+			// falsy value: undefined | null | false | 0 | ""
+			if (!arg || typeof arg !== "object") {
+				return "";
 			}
 
 			// array: ["a", "b", "c"]
@@ -31,6 +31,6 @@ export default function classNames(...args) {
 				.filter((key) => arg[key] && arg.hasOwnProperty(key))
 				.join(" ");
 		})
-		.filter((v) => !!v) // remove empty strings
+		.filter((v) => v) // remove empty strings
 		.join(" ");
 }

--- a/index.js
+++ b/index.js
@@ -1,50 +1,36 @@
-const hasOwn = {}.hasOwnProperty;
+export default function classNames(...args) {
+	return args
+		.map((arg) => {
+			// string: "a"
+			if (typeof arg === "string") {
+				return arg;
+			}
 
-export default function classNames () {
-	let classes = '';
+			// array: ["a", "b", "c"]
+			if (Array.isArray(arg)) {
+				return classNames(...arg);
+			}
 
-	for (let i = 0; i < arguments.length; i++) {
-		const arg = arguments[i];
-		if (arg) {
-			classes = appendClass(classes, parseValue(arg));
-		}
-	}
+			// failed condition: undefined | false | 0
+			if (!arg || typeof arg !== "object") {
+				return "";
+			}
 
-	return classes;
-}
+			// custom toString
+			if (
+				/* has a custom toString method */
+				arg.toString !== Object.prototype.toString &&
+				/* and is not a native toString */
+				!arg.toString.toString().includes("[native code]")
+			) {
+				return arg.toString();
+			}
 
-function parseValue (arg) {
-	if (typeof arg === 'string') {
-		return arg;
-	}
-
-	if (typeof arg !== 'object') {
-		return '';
-	}
-
-	if (Array.isArray(arg)) {
-		return classNames.apply(null, arg);
-	}
-
-	if (arg.toString !== Object.prototype.toString && !arg.toString.toString().includes('[native code]')) {
-		return arg.toString();
-	}
-
-	let classes = '';
-
-	for (const key in arg) {
-		if (hasOwn.call(arg, key) && arg[key]) {
-			classes = appendClass(classes, key);
-		}
-	}
-
-	return classes;
-}
-
-function appendClass (value, newClass) {
-	if (!newClass) {
-		return value;
-	}
-
-	return value ? (value + ' ' + newClass) : newClass;
+			// object: {"a": false, "b": true}
+			return Object.keys(arg)
+				.filter((key) => arg[key] && arg.hasOwnProperty(key))
+				.join(" ");
+		})
+		.filter((v) => !!v) // remove empty strings to prevent duplicate whitespace
+		.join(" ");
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 export default function classNames(...args) {
 	return args
 		.map((arg) => {
+			// falsy value: undefined | null | false | 0 | ""
+			if (!arg) {
+				return "";
+			}
+
 			// string: "a"
 			if (typeof arg === "string") {
 				return arg;
@@ -11,12 +16,7 @@ export default function classNames(...args) {
 				return classNames(...arg);
 			}
 
-			// failed condition: undefined | false | 0
-			if (!arg || typeof arg !== "object") {
-				return "";
-			}
-
-			// custom toString
+			// object with a custom toString method
 			if (
 				/* has a custom toString method */
 				arg.toString !== Object.prototype.toString &&
@@ -31,6 +31,6 @@ export default function classNames(...args) {
 				.filter((key) => arg[key] && arg.hasOwnProperty(key))
 				.join(" ");
 		})
-		.filter((v) => !!v) // remove empty strings to prevent duplicate whitespace
+		.filter((v) => !!v) // remove empty strings
 		.join(" ");
 }


### PR DESCRIPTION
Refactored index.js to reduce bundle size whilst keeping performance

- Changed final condition check in parseValue into an expression
  - this allows the entire function to be turned into an inlined expression
  - inlined this into the top function
- swapped from accumilators to map and joins
  - by using expressions instead, bundlers can inline more code
- removed parseValue
  - it was only used it one place and the classNames function was 3 lines before changes
- removed appendClass
  - after reworking everything I realised I was only using it a single place and it no longer made sense to use
- swapped to `..args` instead of arguments
  - args is an array by default, meaning we can use `.map` without any additional steps
  - we don't have to convert it to an array or do a for loop
- removed `typeof arg !== "object"` check
  - the `!arg` covers 

## Bundle Size

When compiled using microbundle in isolation:

Original:
```
308 B: classnames.js.gz
254 B: classnames.js.br
```

New Version:
```
218 B: classnames.js.gz
178 B: classnames.js.br
```

When built into an actual project

No classNames:
`11372   ./dist/assets/index-CGD-ssac.js`

Original (+890):
`12262   ./dist/assets/index-D8rnffc0.js`

New Version (+299):
`11671   ./dist/assets/index-hh12ETg_.js`

*I created an empty preact project using vite to get the build different in an actual project*

## Benchmark Results

Performance appears unchanged

```
Benchmarking 'strings'.

| Task name | Latency avg (ns) | Latency med (ns) | Throughput avg (ops/s) | Throughput med (ops/s) | Samples |
| --------- | ---------------- | ---------------- | ---------------------- | ---------------------- | ------- |
| reworked  | 121.51 ± 0.19%   | 111.00 ± 1.00    | 8587128 ± 0.01%        | 9009009 ± 81900        | 8229759 |
| original  | 123.50 ± 0.13%   | 120.00 ± 9.00    | 8440112 ± 0.01%        | 8333333 ± 675676       | 8097160 |

Benchmarking 'object'.

| Task name | Latency avg (ns) | Latency med (ns) | Throughput avg (ops/s) | Throughput med (ops/s) | Samples |
| --------- | ---------------- | ---------------- | ---------------------- | ---------------------- | ------- |
| reworked  | 123.12 ± 1.14%   | 110.00 ± 0.00    | 8552463 ± 0.01%        | 9090909 ± 0            | 8122470 |
| original  | 120.44 ± 0.12%   | 111.00 ± 1.00    | 8594657 ± 0.01%        | 9009010 ± 81900        | 8303130 |

Benchmarking 'strings, object'.

| Task name | Latency avg (ns) | Latency med (ns) | Throughput avg (ops/s) | Throughput med (ops/s) | Samples |
| --------- | ---------------- | ---------------- | ---------------------- | ---------------------- | ------- |
| reworked  | 153.61 ± 0.17%   | 141.00 ± 1.00    | 6776792 ± 0.01%        | 7092199 ± 50659        | 6509904 |
| original  | 154.21 ± 0.16%   | 150.00 ± 9.00    | 6727520 ± 0.01%        | 6666667 ± 425532       | 6484668 |

Benchmarking 'mix'.

| Task name | Latency avg (ns) | Latency med (ns) | Throughput avg (ops/s) | Throughput med (ops/s) | Samples |
| --------- | ---------------- | ---------------- | ---------------------- | ---------------------- | ------- |
| reworked  | 233.67 ± 0.68%   | 211.00 ± 1.00    | 4543994 ± 0.01%        | 4739336 ± 22568        | 4279555 |
| original  | 237.36 ± 0.88%   | 221.00 ± 1.00    | 4436742 ± 0.01%        | 4524887 ± 20568        | 4213018 |

Benchmarking 'arrays'.

| Task name | Latency avg (ns) | Latency med (ns) | Throughput avg (ops/s) | Throughput med (ops/s) | Samples |
| --------- | ---------------- | ---------------- | ---------------------- | ---------------------- | ------- |
| reworked  | 375.24 ± 0.11%   | 361.00 ± 1.00    | 2730653 ± 0.01%        | 2770083 ± 7695         | 2664987 |
| original  | 373.86 ± 0.12%   | 361.00 ± 10.00   | 2743952 ± 0.01%        | 2770083 ± 78920        | 2674781 |
```