### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 Install from the [npm registry](https://www.npmjs.com/) with your package manager:
 ```bash
 npm install classnames
+# or
+deno install classnames
 ```
 
 Use with [Node.js](https://nodejs.org/en/), [Browserify](https://browserify.org/), or [webpack](https://webpack.github.io/):


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The README shows `npm install classnames`. Since Deno is a drop-in replacement for npm these days, this adds a Deno line alongside it:

```sh
deno install classnames
```

Docs-only change (classnames resolves and installs the same way under Deno). Totally fine to close this if you'd rather keep it npm-only. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
