### PR TITLE
docs: document conditional string classNames pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ classNames('foo', { bar: true, duck: false }, 'baz', { quux: true }); // => 'foo
 
 // other falsy values are just ignored
 classNames(null, false, 'bar', undefined, 0, { baz: null }, ''); // => 'bar'
+
+// conditional strings (falsy results are ignored)
+classNames('foo', true && 'bar'); // => 'foo bar'
+classNames('foo', false && 'bar'); // => 'foo'
 ```
 
 Arrays will be recursively flattened as per the rules above:


### PR DESCRIPTION
## Summary
- Documents the common `condition && 'class'` pattern in the Usage examples.
- Fixes #511

## Test plan
- [ ] Confirm the new README examples match existing falsy-value behavior
- [ ] Skim Usage section for consistent style with nearby examples