### PR TITLE
Guard the custom-toString check against objects without a callable toString

### DIFF
--- a/bind.js
+++ b/bind.js
@@ -26,7 +26,7 @@ function parseValue (arg) {
 		return classNames.apply(this, arg);
 	}
 
-	if (arg.toString !== Object.prototype.toString && !arg.toString.toString().includes('[native code]')) {
+	if (typeof arg.toString === 'function' && arg.toString !== Object.prototype.toString && !arg.toString.toString().includes('[native code]')) {
 		return arg.toString();
 	}
 

--- a/dedupe.js
+++ b/dedupe.js
@@ -53,6 +53,7 @@ const hasOwn = {}.hasOwnProperty;
 
 function appendObject (classSet, object) {
 	if (
+		typeof object.toString === 'function' &&
 		object.toString !== Object.prototype.toString &&
 		!object.toString.toString().includes('[native code]')
 	) {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function parseValue (arg) {
 		return classNames.apply(null, arg);
 	}
 
-	if (arg.toString !== Object.prototype.toString && !arg.toString.toString().includes('[native code]')) {
+	if (typeof arg.toString === 'function' && arg.toString !== Object.prototype.toString && !arg.toString.toString().includes('[native code]')) {
 		return arg.toString();
 	}
 

--- a/tests/bind.js
+++ b/tests/bind.js
@@ -76,6 +76,20 @@ describe('bind', () => {
 				toString: () => { return 'classFromMethod'; }
 			}), 'classFromMethod');
 		});
+
+		it('handles objects with a null prototype', () => {
+			const dict = Object.create(null);
+			dict.a = true;
+			dict.b = false;
+
+			assert.equal(classNames(dict), 'a');
+			assert.equal(classNames(Object.groupBy(['a', 'b'], (x) => x)), 'a b');
+		});
+
+		it('handles objects whose toString is not callable', () => {
+			assert.equal(classNames({toString: null, a: true}), 'a');
+			assert.equal(classNames({toString: undefined, a: true}), 'a');
+		});
 	});
 
 	describe('classNamesBound', () => {
@@ -160,6 +174,20 @@ describe('bind', () => {
 			class Class2 extends Class1 {}
 
 			assert.equal(classNamesBound(new Class2()), 'classFromMethod');
+		});
+
+		it('handles objects with a null prototype', () => {
+			const dict = Object.create(null);
+			dict.a = true;
+			dict.b = false;
+
+			assert.equal(classNamesBound(dict), '#a');
+			assert.equal(classNamesBound(Object.groupBy(['a', 'b'], (x) => x)), '#a #b');
+		});
+
+		it('handles objects whose toString is not callable', () => {
+			assert.equal(classNamesBound({toString: null, a: true}), '#a');
+			assert.equal(classNamesBound({toString: undefined, a: true}), '#a');
 		});
 	});
 })

--- a/tests/dedupe.js
+++ b/tests/dedupe.js
@@ -86,4 +86,18 @@ describe('dedupe', () => {
 
 		assert.equal(dedupe(new Class2()), 'classFromMethod');
 	});
+
+	it('handles objects with a null prototype', () => {
+		const dict = Object.create(null);
+		dict.a = true;
+		dict.b = false;
+
+		assert.equal(dedupe(dict), 'a');
+		assert.equal(dedupe(Object.groupBy(['a', 'b'], (x) => x)), 'a b');
+	});
+
+	it('handles objects whose toString is not callable', () => {
+		assert.equal(dedupe({toString: null, a: true}), 'a');
+		assert.equal(dedupe({toString: undefined, a: true}), 'a');
+	});
 });

--- a/tests/index.js
+++ b/tests/index.js
@@ -104,6 +104,20 @@ describe('classNames', () => {
 		assert.equal(classNames(new Class2()), 'classFromMethod');
 	});
 
+	it('handles objects with a null prototype', () => {
+		const dict = Object.create(null);
+		dict.a = true;
+		dict.b = false;
+
+		assert.equal(classNames(dict), 'a');
+		assert.equal(classNames(Object.groupBy(['a', 'b'], (x) => x)), 'a b');
+	});
+
+	it('handles objects whose toString is not callable', () => {
+		assert.equal(classNames({toString: null, a: true}), 'a');
+		assert.equal(classNames({toString: undefined, a: true}), 'a');
+	});
+
 	it('handles objects in a VM', () => {
 		const context = { classNames, output: undefined };
 		vm.createContext(context);


### PR DESCRIPTION
All three entry points throw `TypeError` on objects that lack a callable `toString` - and that includes a shape modern JavaScript hands out routinely: `Object.groupBy` returns null-prototype objects.

```js
classNames(Object.create(null));            // TypeError: Cannot read properties of undefined (reading 'toString')
classNames(Object.groupBy([1, 2], String)); // same
classNames({ toString: null, a: true });    // TypeError: toString is not a function
```

The custom-toString check in each module reads `arg.toString` and calls it (via the `toString.toString()` inclusion test) without verifying the method exists and is callable. The fix adds one `typeof arg.toString === 'function'` guard ahead of the existing check, at all three sites (`index.js`, `bind.js`, `dedupe.js`).

**Behavior preserved**: the guard can only stop the custom-toString branch from being taken, never start it. An object with a callable custom `toString` still stringifies through it (the existing `classFromMethod` and cross-realm VM tests still pass), a plain object still falls through to own-key iteration, and the only inputs whose result changes are those that previously threw - verified with a differential sweep between the unfixed and fixed trees.

**Performance**: per CONTRIBUTING's concern - the cost is one `typeof` on a property already being read on that path, and only on the object branch; the string/number fast paths are untouched. Happy to run the benchmark suite comparison if you'd like it in the record.

**Tests**: eight regression tests - null-prototype object, `Object.groupBy` output, and non-callable `toString`, per module and for both the bound and unbound bind forms. They fail on `main` (TypeError) and pass with the fix; `npm test` and `npm run check-types` are green.

---

Provenance, for transparency: this defect was found by an automated audit loop I run against open-source projects; the patch and its verification were reviewed by me before filing, and I'm happy to answer any questions during review.
